### PR TITLE
Replace MediatR with Paramore.Brighter

### DIFF
--- a/src/EChamado/Server/EChamado.Server.Application/Common/Behaviours/UnhandledExceptionBehaviour.cs
+++ b/src/EChamado/Server/EChamado.Server.Application/Common/Behaviours/UnhandledExceptionBehaviour.cs
@@ -1,28 +1,44 @@
-﻿using MediatR;
-using Microsoft.Extensions.Logging;
+﻿using Microsoft.Extensions.Logging;
+using Paramore.Brighter;
 
 namespace EChamado.Server.Application.Common.Behaviours;
 
-public class UnhandledExceptionBehaviour<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse> where TRequest : notnull
+/// <summary>
+/// Attribute to mark handlers that should have exception logging.
+/// </summary>
+public class RequestLoggingAttribute : RequestHandlerAttribute
+{
+    public RequestLoggingAttribute(int step, HandlerTiming timing = HandlerTiming.Before)
+        : base(step, timing)
+    {
+    }
+}
+
+/// <summary>
+/// Exception handling and logging handler for Brighter pipeline.
+/// Logs unhandled exceptions before re-throwing them.
+/// </summary>
+public class UnhandledExceptionHandler<TRequest> : RequestHandlerAsync<TRequest>
+    where TRequest : class, IRequest
 {
     private readonly ILogger<TRequest> _logger;
 
-    public UnhandledExceptionBehaviour(ILogger<TRequest> logger)
+    public UnhandledExceptionHandler(ILogger<TRequest> logger)
     {
         _logger = logger;
     }
 
-    public async Task<TResponse> Handle(TRequest request, RequestHandlerDelegate<TResponse> next, CancellationToken cancellationToken)
+    public override async Task<TRequest> HandleAsync(TRequest command, CancellationToken cancellationToken = default)
     {
         try
         {
-            return await next();
+            return await base.HandleAsync(command, cancellationToken);
         }
         catch (Exception ex)
         {
             var requestName = typeof(TRequest).Name;
 
-            _logger.LogError(ex, "Request: Unhandled Exception for Request {Name} {@Request}", requestName, request);
+            _logger.LogError(ex, "Request: Unhandled Exception for Request {Name} {@Request}", requestName, command);
 
             throw;
         }

--- a/src/EChamado/Server/EChamado.Server.Application/Common/Behaviours/ValidationBehaviour.cs
+++ b/src/EChamado/Server/EChamado.Server.Application/Common/Behaviours/ValidationBehaviour.cs
@@ -1,26 +1,44 @@
 ﻿using FluentValidation;
-using MediatR;
+using Microsoft.Extensions.DependencyInjection;
+using Paramore.Brighter;
 
 namespace EChamado.Server.Application.Common.Behaviours;
 
-public class ValidationBehaviour<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse>
- where TRequest : notnull
+/// <summary>
+/// Attribute to mark handlers that should have validation.
+/// </summary>
+public class RequestValidationAttribute : RequestHandlerAttribute
 {
-    private readonly IEnumerable<IValidator<TRequest>> _validators;
-
-    public ValidationBehaviour(IEnumerable<IValidator<TRequest>> validators)
+    public RequestValidationAttribute(int step, HandlerTiming timing = HandlerTiming.Before)
+        : base(step, timing)
     {
-        _validators = validators;
+    }
+}
+
+/// <summary>
+/// Validation handler for Brighter pipeline.
+/// Runs FluentValidation validators before the main handler executes.
+/// </summary>
+public class ValidationHandler<TRequest> : RequestHandlerAsync<TRequest>
+    where TRequest : class, IRequest
+{
+    private readonly IServiceProvider _serviceProvider;
+
+    public ValidationHandler(IServiceProvider serviceProvider)
+    {
+        _serviceProvider = serviceProvider;
     }
 
-    public async Task<TResponse> Handle(TRequest request, RequestHandlerDelegate<TResponse> next, CancellationToken cancellationToken)
+    public override async Task<TRequest> HandleAsync(TRequest command, CancellationToken cancellationToken = default)
     {
-        if (_validators.Any())
+        var validators = _serviceProvider.GetServices<IValidator<TRequest>>();
+
+        if (validators.Any())
         {
-            var context = new ValidationContext<TRequest>(request);
+            var context = new ValidationContext<TRequest>(command);
 
             var validationResults = await Task.WhenAll(
-                _validators.Select(v =>
+                validators.Select(v =>
                     v.ValidateAsync(context, cancellationToken)));
 
             var failures = validationResults
@@ -31,7 +49,8 @@ public class ValidationBehaviour<TRequest, TResponse> : IPipelineBehavior<TReque
             if (failures.Any())
                 throw new ValidationException(failures);
         }
-        return await next();
+
+        return await base.HandleAsync(command, cancellationToken);
     }
 }
 

--- a/src/EChamado/Server/EChamado.Server.Application/Common/Messaging/BrighterRequest.cs
+++ b/src/EChamado/Server/EChamado.Server.Application/Common/Messaging/BrighterRequest.cs
@@ -1,0 +1,20 @@
+using Paramore.Brighter;
+
+namespace EChamado.Server.Application.Common.Messaging;
+
+/// <summary>
+/// Base class for requests that return a result.
+/// This allows Brighter to work with return values similar to MediatR.
+/// </summary>
+public abstract class BrighterRequest<TResult> : IRequest
+{
+    /// <summary>
+    /// The result of the request, set by the handler.
+    /// </summary>
+    public TResult? Result { get; set; }
+
+    /// <summary>
+    /// Unique identifier for this request.
+    /// </summary>
+    public Guid Id { get; set; } = Guid.NewGuid();
+}

--- a/src/EChamado/Server/EChamado.Server.Application/Common/Messaging/CommandProcessorExtensions.cs
+++ b/src/EChamado/Server/EChamado.Server.Application/Common/Messaging/CommandProcessorExtensions.cs
@@ -1,0 +1,38 @@
+using Paramore.Brighter;
+
+namespace EChamado.Server.Application.Common.Messaging;
+
+/// <summary>
+/// Extension methods for IAmACommandProcessor to provide MediatR-like syntax.
+/// </summary>
+public static class CommandProcessorExtensions
+{
+    /// <summary>
+    /// Sends a request and returns the result.
+    /// This provides a similar API to MediatR's Send method.
+    /// </summary>
+    public static async Task<TResult> Send<TResult>(
+        this IAmACommandProcessor commandProcessor,
+        BrighterRequest<TResult> request,
+        CancellationToken cancellationToken = default)
+    {
+        // Send the request using Brighter
+        await commandProcessor.SendAsync(request, cancellationToken: cancellationToken);
+
+        // Return the result that was set by the handler
+        return request.Result!;
+    }
+
+    /// <summary>
+    /// Publishes an event to all handlers.
+    /// This provides a similar API to MediatR's Publish method.
+    /// </summary>
+    public static async Task Publish<TEvent>(
+        this IAmACommandProcessor commandProcessor,
+        TEvent @event,
+        CancellationToken cancellationToken = default)
+        where TEvent : class, IRequest
+    {
+        await commandProcessor.PublishAsync(@event, cancellationToken: cancellationToken);
+    }
+}

--- a/src/EChamado/Server/EChamado.Server.Application/Configuration/DependencyInjection.cs
+++ b/src/EChamado/Server/EChamado.Server.Application/Configuration/DependencyInjection.cs
@@ -2,8 +2,10 @@
 using EChamado.Server.Application.Services;
 using EChamado.Server.Domain.Services.Interface;
 using FluentValidation;
-using MediatR;
 using Microsoft.Extensions.DependencyInjection;
+using Paramore.Brighter;
+using Paramore.Brighter.Extensions.DependencyInjection;
+using System.Reflection;
 
 namespace EChamado.Server.Application.Configuration;
 
@@ -15,12 +17,17 @@ public static class DependencyInjection
 
         services.AddValidatorsFromAssembly(typeof(DependencyInjection).Assembly);
 
-        services.AddMediatR(cfg =>
+        // Configure Paramore.Brighter
+        services.AddBrighter(options =>
         {
-            cfg.RegisterServicesFromAssembly(typeof(DependencyInjection).Assembly);
-            cfg.AddBehavior(typeof(IPipelineBehavior<,>), typeof(UnhandledExceptionBehaviour<,>));
-            cfg.AddBehavior(typeof(IPipelineBehavior<,>), typeof(ValidationBehaviour<,>));
-        });
+            // Register all handlers from this assembly
+            options.HandlerLifetime = ServiceLifetime.Scoped;
+        })
+        .AutoFromAssemblies(typeof(DependencyInjection).Assembly);
+
+        // Register the generic validation and exception handlers
+        services.AddTransient(typeof(ValidationHandler<>));
+        services.AddTransient(typeof(UnhandledExceptionHandler<>));
 
         return services;
     }

--- a/src/EChamado/Server/EChamado.Server.Application/EChamado.Server.Application.csproj
+++ b/src/EChamado/Server/EChamado.Server.Application/EChamado.Server.Application.csproj
@@ -32,7 +32,8 @@
     <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.11.0" />
     <PackageReference Include="LinqKit.Core" Version="1.2.8" />
     <PackageReference Include="LinqKit.Microsoft.EntityFrameworkCore" Version="9.0.8" />
-    <PackageReference Include="MediatR" Version="12.4.1" />
+    <PackageReference Include="Paramore.Brighter" Version="10.1.2" />
+    <PackageReference Include="Paramore.Brighter.Extensions.DependencyInjection" Version="10.1.2" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.2" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.2" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.2" />

--- a/src/EChamado/Server/EChamado.Server.Application/UseCases/Auth/Commands/GetTokenCommand.cs
+++ b/src/EChamado/Server/EChamado.Server.Application/UseCases/Auth/Commands/GetTokenCommand.cs
@@ -1,11 +1,19 @@
-﻿using EChamado.Shared.Responses;
+﻿using EChamado.Server.Application.Common.Messaging;
+using EChamado.Shared.Responses;
 using EChamado.Shared.ViewModels.Auth;
-using MediatR;
 
 namespace EChamado.Server.Application.UseCases.Auth.Commands;
 
-public class GetTokenCommand : 
-    IRequest<BaseResult<LoginResponseViewModel>>
+public class GetTokenCommand : BrighterRequest<BaseResult<LoginResponseViewModel>>
 {
     public string Email { get; set; } = string.Empty;
+
+    public GetTokenCommand()
+    {
+    }
+
+    public GetTokenCommand(string email)
+    {
+        Email = email;
+    }
 }

--- a/src/EChamado/Server/EChamado.Server.Application/UseCases/Auth/Commands/Handlers/GetTokenCommandHandler.cs
+++ b/src/EChamado/Server/EChamado.Server.Application/UseCases/Auth/Commands/Handlers/GetTokenCommandHandler.cs
@@ -1,11 +1,12 @@
-﻿using EChamado.Server.Domain.Domains.Identities;
+﻿using EChamado.Server.Application.Common.Behaviours;
+using EChamado.Server.Domain.Domains.Identities;
 using EChamado.Server.Domain.Services.Interface;
 using EChamado.Shared.Responses;
 using EChamado.Shared.Shared.Settings;
 using EChamado.Shared.ViewModels.Auth;
-using MediatR;
 using Microsoft.Extensions.Options;
 using Microsoft.IdentityModel.Tokens;
+using Paramore.Brighter;
 using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
 using System.Text;
@@ -15,11 +16,15 @@ namespace EChamado.Server.Application.UseCases.Auth.Commands.Handlers;
 public class GetTokenCommandHandler(
     IOptions<AppSettings> appSettings,
     IApplicationUserService applicationUserService
-    ) : IRequestHandler<GetTokenCommand, BaseResult<LoginResponseViewModel>>
+    ) : RequestHandlerAsync<GetTokenCommand>
 {
-    public async Task<BaseResult<LoginResponseViewModel>> Handle(GetTokenCommand request, CancellationToken cancellationToken)
+    [RequestLogging(0, HandlerTiming.Before)]
+    [RequestValidation(1, HandlerTiming.Before)]
+    public override async Task<GetTokenCommand> HandleAsync(GetTokenCommand command, CancellationToken cancellationToken = default)
     {
-        return await GetJwt(request.Email);
+        var result = await GetJwt(command.Email);
+        command.Result = result;
+        return await base.HandleAsync(command, cancellationToken);
     }
 
     public async Task<BaseResult<LoginResponseViewModel>> GetJwt(string email)

--- a/src/EChamado/Server/EChamado.Server.Application/UseCases/Auth/Commands/LoginUserCommand.cs
+++ b/src/EChamado/Server/EChamado.Server.Application/UseCases/Auth/Commands/LoginUserCommand.cs
@@ -1,11 +1,21 @@
-﻿using EChamado.Shared.Responses;
+﻿using EChamado.Server.Application.Common.Messaging;
+using EChamado.Shared.Responses;
 using EChamado.Shared.ViewModels.Auth;
-using MediatR;
 
 namespace EChamado.Server.Application.UseCases.Auth.Commands;
 
-public class LoginUserCommand : IRequest<BaseResult<LoginResponseViewModel>>
+public class LoginUserCommand : BrighterRequest<BaseResult<LoginResponseViewModel>>
 {
     public string Email { get; set; } = string.Empty;
     public string Password { get; set; } = string.Empty;
+
+    public LoginUserCommand()
+    {
+    }
+
+    public LoginUserCommand(string email, string password)
+    {
+        Email = email;
+        Password = password;
+    }
 }

--- a/src/EChamado/Server/EChamado.Server.Application/UseCases/Auth/Commands/RegisterUserCommand.cs
+++ b/src/EChamado/Server/EChamado.Server.Application/UseCases/Auth/Commands/RegisterUserCommand.cs
@@ -1,21 +1,30 @@
-﻿using EChamado.Server.Domain.Domains.Identities;
+﻿using EChamado.Server.Application.Common.Messaging;
+using EChamado.Server.Domain.Domains.Identities;
 using EChamado.Shared.Responses;
 using EChamado.Shared.ViewModels.Auth;
-using MediatR;
 using System.ComponentModel.DataAnnotations;
 
 namespace EChamado.Server.Application.UseCases.Auth.Commands;
 
-public class RegisterUserCommand : IRequest<BaseResult<LoginResponseViewModel>>
+public class RegisterUserCommand : BrighterRequest<BaseResult<LoginResponseViewModel>>
 {
     [Required(ErrorMessage = "O campo {0} é requerido")]
     [EmailAddress(ErrorMessage = "O campo {0} é inválido")]
-    public required string Email { get; set; }
+    public string Email { get; set; } = string.Empty;
 
     [Required(ErrorMessage = "O campo {0} é requeridod")]
     [StringLength(255, ErrorMessage = "O campo  {0} deve está entre {2} e {1} caracteres", MinimumLength = 6)]
-    public required string Password { get; set; }
+    public string Password { get; set; } = string.Empty;
 
+    public RegisterUserCommand()
+    {
+    }
+
+    public RegisterUserCommand(string email, string password)
+    {
+        Email = email;
+        Password = password;
+    }
 
     public ApplicationUser ToDomain()
     {

--- a/src/EChamado/Server/EChamado.Server.Application/UseCases/Auth/Notifications/Handlers/AuthNotificationHandler.cs
+++ b/src/EChamado/Server/EChamado.Server.Application/UseCases/Auth/Notifications/Handlers/AuthNotificationHandler.cs
@@ -1,26 +1,22 @@
-﻿using MediatR;
+﻿using Paramore.Brighter;
 using Microsoft.Extensions.Logging;
 
 namespace EChamado.Server.Application.UseCases.Auth.Notifications.Handlers;
 
-public class AuthNotificationHandler(ILogger<AuthNotificationHandler> logger) :
-    INotificationHandler<LoginUserNotification>,
-    INotificationHandler<RegisterUserNotification>
+public class LoginUserNotificationHandler(ILogger<LoginUserNotificationHandler> logger) : RequestHandlerAsync<LoginUserNotification>
 {
-
-    public Task Handle(LoginUserNotification notification, CancellationToken cancellationToken)
+    public override async Task<LoginUserNotification> HandleAsync(LoginUserNotification notification, CancellationToken cancellationToken = default)
     {
-        return Task.Run(() =>
-        {
-            logger.LogInformation("LoginUserNotification: " + notification.Message);
-        });
+        logger.LogInformation("LoginUserNotification: " + notification.Message);
+        return await base.HandleAsync(notification, cancellationToken);
     }
+}
 
-    public Task Handle(RegisterUserNotification notification, CancellationToken cancellationToken)
+public class RegisterUserNotificationHandler(ILogger<RegisterUserNotificationHandler> logger) : RequestHandlerAsync<RegisterUserNotification>
+{
+    public override async Task<RegisterUserNotification> HandleAsync(RegisterUserNotification notification, CancellationToken cancellationToken = default)
     {
-        return Task.Run(() =>
-        {
-            logger.LogInformation("RegisterUserNotification: " + notification.Message);
-        });
+        logger.LogInformation("RegisterUserNotification: " + notification.Message);
+        return await base.HandleAsync(notification, cancellationToken);
     }
 }

--- a/src/EChamado/Server/EChamado.Server.Application/UseCases/Auth/Notifications/LoginUserNotification.cs
+++ b/src/EChamado/Server/EChamado.Server.Application/UseCases/Auth/Notifications/LoginUserNotification.cs
@@ -1,13 +1,18 @@
-﻿using MediatR;
+﻿using Paramore.Brighter;
 using System.Text.Json;
 
 namespace EChamado.Server.Application.UseCases.Auth.Notifications;
 
-public class LoginUserNotification : INotification
+public class LoginUserNotification : IRequest
 {
+    public Guid Id { get; set; }
     public string Email { get; set; } = string.Empty;
-
     public string Message { get; set; } = string.Empty;
+
+    public LoginUserNotification()
+    {
+        Id = Guid.NewGuid();
+    }
 
     public override string? ToString()
     {

--- a/src/EChamado/Server/EChamado.Server.Application/UseCases/Auth/Notifications/RegisterUserNotification.cs
+++ b/src/EChamado/Server/EChamado.Server.Application/UseCases/Auth/Notifications/RegisterUserNotification.cs
@@ -1,13 +1,18 @@
-﻿using MediatR;
+﻿using Paramore.Brighter;
 using System.Text.Json;
 
 namespace EChamado.Server.Application.UseCases.Auth.Notifications;
 
-public class RegisterUserNotification : INotification
+public class RegisterUserNotification : IRequest
 {
+    public Guid Id { get; set; }
     public string Email { get; set; } = string.Empty;
-
     public string Message { get; set; } = string.Empty;
+
+    public RegisterUserNotification()
+    {
+        Id = Guid.NewGuid();
+    }
 
     public override string? ToString()
     {

--- a/src/EChamado/Server/EChamado.Server.Application/UseCases/Categories/Commands/CreateCategoryCommand.cs
+++ b/src/EChamado/Server/EChamado.Server.Application/UseCases/Categories/Commands/CreateCategoryCommand.cs
@@ -1,9 +1,20 @@
+using EChamado.Server.Application.Common.Messaging;
 using EChamado.Shared.Responses;
-using MediatR;
 
 namespace EChamado.Server.Application.UseCases.Categories.Commands;
 
-public record CreateCategoryCommand(
-    string Name,
-    string Description
-) : IRequest<BaseResult<Guid>>;
+public class CreateCategoryCommand : BrighterRequest<BaseResult<Guid>>
+{
+    public string Name { get; set; } = string.Empty;
+    public string Description { get; set; } = string.Empty;
+
+    public CreateCategoryCommand()
+    {
+    }
+
+    public CreateCategoryCommand(string name, string description)
+    {
+        Name = name;
+        Description = description;
+    }
+}

--- a/src/EChamado/Server/EChamado.Server.Application/UseCases/Categories/Commands/CreateCategoryCommandHandler.cs
+++ b/src/EChamado/Server/EChamado.Server.Application/UseCases/Categories/Commands/CreateCategoryCommandHandler.cs
@@ -1,22 +1,25 @@
+using EChamado.Server.Application.Common.Behaviours;
 using EChamado.Server.Application.UseCases.Categories.Notifications;
 using EChamado.Server.Domain.Domains.Categories;
 using EChamado.Server.Domain.Exceptions;
 using EChamado.Server.Domain.Repositories;
 using EChamado.Shared.Responses;
-using MediatR;
 using Microsoft.Extensions.Logging;
+using Paramore.Brighter;
 
 namespace EChamado.Server.Application.UseCases.Categories.Commands;
 
 public class CreateCategoryCommandHandler(
     IUnitOfWork unitOfWork,
-    IMediator mediator,
+    IAmACommandProcessor commandProcessor,
     ILogger<CreateCategoryCommandHandler> logger) :
-    IRequestHandler<CreateCategoryCommand, BaseResult<Guid>>
+    RequestHandlerAsync<CreateCategoryCommand>
 {
-    public async Task<BaseResult<Guid>> Handle(CreateCategoryCommand request, CancellationToken cancellationToken)
+    [RequestLogging(0, HandlerTiming.Before)]
+    [RequestValidation(1, HandlerTiming.Before)]
+    public override async Task<CreateCategoryCommand> HandleAsync(CreateCategoryCommand command, CancellationToken cancellationToken = default)
     {
-        var entity = Category.Create(request.Name, request.Description);
+        var entity = Category.Create(command.Name, command.Description);
 
         if (!entity.IsValid())
         {
@@ -30,10 +33,12 @@ public class CreateCategoryCommandHandler(
 
         await unitOfWork.CommitAsync();
 
-        await mediator.Publish(new CreatedCategoryNotification(entity.Id, entity.Name, entity.Description));
+        await commandProcessor.PublishAsync(new CreatedCategoryNotification(entity.Id, entity.Name, entity.Description), cancellationToken: cancellationToken);
 
         logger.LogInformation("Category {CategoryId} created successfully", entity.Id);
 
-        return new BaseResult<Guid>(entity.Id);
+        command.Result = new BaseResult<Guid>(entity.Id);
+
+        return await base.HandleAsync(command, cancellationToken);
     }
 }

--- a/src/EChamado/Server/EChamado.Server.Application/UseCases/Categories/Commands/CreateSubCategoryCommand.cs
+++ b/src/EChamado/Server/EChamado.Server.Application/UseCases/Categories/Commands/CreateSubCategoryCommand.cs
@@ -1,10 +1,22 @@
+using EChamado.Server.Application.Common.Messaging;
 using EChamado.Shared.Responses;
-using MediatR;
 
 namespace EChamado.Server.Application.UseCases.Categories.Commands;
 
-public record CreateSubCategoryCommand(
-    string Name,
-    string Description,
-    Guid CategoryId
-) : IRequest<BaseResult<Guid>>;
+public class CreateSubCategoryCommand : BrighterRequest<BaseResult<Guid>>
+{
+    public string Name { get; set; } = string.Empty;
+    public string Description { get; set; } = string.Empty;
+    public Guid CategoryId { get; set; } = default!;
+
+    public CreateSubCategoryCommand()
+    {
+    }
+
+    public CreateSubCategoryCommand(string name, string description, Guid categoryId)
+    {
+        Name = name;
+        Description = description;
+        CategoryId = categoryId;
+    }
+}

--- a/src/EChamado/Server/EChamado.Server.Application/UseCases/Categories/Commands/DeleteCategoryCommand.cs
+++ b/src/EChamado/Server/EChamado.Server.Application/UseCases/Categories/Commands/DeleteCategoryCommand.cs
@@ -1,6 +1,18 @@
+using EChamado.Server.Application.Common.Messaging;
 using EChamado.Shared.Responses;
-using MediatR;
 
 namespace EChamado.Server.Application.UseCases.Categories.Commands;
 
-public record DeleteCategoryCommand(Guid CategoryId) : IRequest<BaseResult>;
+public class DeleteCategoryCommand : BrighterRequest<BaseResult>
+{
+    public Guid CategoryId { get; set; } = default!;
+
+    public DeleteCategoryCommand()
+    {
+    }
+
+    public DeleteCategoryCommand(Guid categoryId)
+    {
+        CategoryId = categoryId;
+    }
+}

--- a/src/EChamado/Server/EChamado.Server.Application/UseCases/Categories/Commands/DeleteSubCategoryCommand.cs
+++ b/src/EChamado/Server/EChamado.Server.Application/UseCases/Categories/Commands/DeleteSubCategoryCommand.cs
@@ -1,6 +1,18 @@
+using EChamado.Server.Application.Common.Messaging;
 using EChamado.Shared.Responses;
-using MediatR;
 
 namespace EChamado.Server.Application.UseCases.Categories.Commands;
 
-public record DeleteSubCategoryCommand(Guid SubCategoryId) : IRequest<BaseResult>;
+public class DeleteSubCategoryCommand : BrighterRequest<BaseResult>
+{
+    public Guid SubCategoryId { get; set; } = default!;
+
+    public DeleteSubCategoryCommand()
+    {
+    }
+
+    public DeleteSubCategoryCommand(Guid subCategoryId)
+    {
+        SubCategoryId = subCategoryId;
+    }
+}

--- a/src/EChamado/Server/EChamado.Server.Application/UseCases/Categories/Commands/UpdateCategoryCommand.cs
+++ b/src/EChamado/Server/EChamado.Server.Application/UseCases/Categories/Commands/UpdateCategoryCommand.cs
@@ -1,10 +1,22 @@
+using EChamado.Server.Application.Common.Messaging;
 using EChamado.Shared.Responses;
-using MediatR;
 
 namespace EChamado.Server.Application.UseCases.Categories.Commands;
 
-public record UpdateCategoryCommand(
-    Guid Id,
-    string Name,
-    string Description
-) : IRequest<BaseResult>;
+public class UpdateCategoryCommand : BrighterRequest<BaseResult>
+{
+    public Guid Id { get; set; } = default!;
+    public string Name { get; set; } = string.Empty;
+    public string Description { get; set; } = string.Empty;
+
+    public UpdateCategoryCommand()
+    {
+    }
+
+    public UpdateCategoryCommand(Guid id, string name, string description)
+    {
+        Id = id;
+        Name = name;
+        Description = description;
+    }
+}

--- a/src/EChamado/Server/EChamado.Server.Application/UseCases/Categories/Commands/UpdateSubCategoryCommand.cs
+++ b/src/EChamado/Server/EChamado.Server.Application/UseCases/Categories/Commands/UpdateSubCategoryCommand.cs
@@ -1,11 +1,24 @@
+using EChamado.Server.Application.Common.Messaging;
 using EChamado.Shared.Responses;
-using MediatR;
 
 namespace EChamado.Server.Application.UseCases.Categories.Commands;
 
-public record UpdateSubCategoryCommand(
-    Guid Id,
-    string Name,
-    string Description,
-    Guid CategoryId
-) : IRequest<BaseResult>;
+public class UpdateSubCategoryCommand : BrighterRequest<BaseResult>
+{
+    public Guid Id { get; set; } = default!;
+    public string Name { get; set; } = string.Empty;
+    public string Description { get; set; } = string.Empty;
+    public Guid CategoryId { get; set; } = default!;
+
+    public UpdateSubCategoryCommand()
+    {
+    }
+
+    public UpdateSubCategoryCommand(Guid id, string name, string description, Guid categoryId)
+    {
+        Id = id;
+        Name = name;
+        Description = description;
+        CategoryId = categoryId;
+    }
+}

--- a/src/EChamado/Server/EChamado.Server.Application/UseCases/Categories/Notifications/CreatedCategoryNotification.cs
+++ b/src/EChamado/Server/EChamado.Server.Application/UseCases/Categories/Notifications/CreatedCategoryNotification.cs
@@ -1,13 +1,18 @@
-using MediatR;
+using Paramore.Brighter;
 using System.Text.Json;
 
 namespace EChamado.Server.Application.UseCases.Categories.Notifications;
 
-public class CreatedCategoryNotification : INotification
+public class CreatedCategoryNotification : IRequest
 {
     public Guid Id { get; set; }
     public string Name { get; set; } = string.Empty;
     public string Description { get; set; } = string.Empty;
+
+    public CreatedCategoryNotification()
+    {
+        Id = Guid.NewGuid();
+    }
 
     public CreatedCategoryNotification(Guid id, string name, string description)
     {

--- a/src/EChamado/Server/EChamado.Server.Application/UseCases/Categories/Notifications/CreatedSubCategoryNotification.cs
+++ b/src/EChamado/Server/EChamado.Server.Application/UseCases/Categories/Notifications/CreatedSubCategoryNotification.cs
@@ -1,14 +1,19 @@
-using MediatR;
+using Paramore.Brighter;
 using System.Text.Json;
 
 namespace EChamado.Server.Application.UseCases.Categories.Notifications;
 
-public class CreatedSubCategoryNotification : INotification
+public class CreatedSubCategoryNotification : IRequest
 {
     public Guid Id { get; set; }
     public string Name { get; set; } = string.Empty;
     public string Description { get; set; } = string.Empty;
     public Guid CategoryId { get; set; }
+
+    public CreatedSubCategoryNotification()
+    {
+        Id = Guid.NewGuid();
+    }
 
     public CreatedSubCategoryNotification(Guid id, string name, string description, Guid categoryId)
     {

--- a/src/EChamado/Server/EChamado.Server.Application/UseCases/Categories/Notifications/DeletedCategoryNotification.cs
+++ b/src/EChamado/Server/EChamado.Server.Application/UseCases/Categories/Notifications/DeletedCategoryNotification.cs
@@ -1,13 +1,18 @@
-using MediatR;
+using Paramore.Brighter;
 using System.Text.Json;
 
 namespace EChamado.Server.Application.UseCases.Categories.Notifications;
 
-public class DeletedCategoryNotification : INotification
+public class DeletedCategoryNotification : IRequest
 {
     public Guid Id { get; set; }
     public string Name { get; set; } = string.Empty;
     public string Description { get; set; } = string.Empty;
+
+    public DeletedCategoryNotification()
+    {
+        Id = Guid.NewGuid();
+    }
 
     public DeletedCategoryNotification(Guid id, string name, string description)
     {

--- a/src/EChamado/Server/EChamado.Server.Application/UseCases/Categories/Notifications/DeletedSubCategoryNotification.cs
+++ b/src/EChamado/Server/EChamado.Server.Application/UseCases/Categories/Notifications/DeletedSubCategoryNotification.cs
@@ -1,13 +1,18 @@
-using MediatR;
+using Paramore.Brighter;
 using System.Text.Json;
 
 namespace EChamado.Server.Application.UseCases.Categories.Notifications;
 
-public class DeletedSubCategoryNotification : INotification
+public class DeletedSubCategoryNotification : IRequest
 {
     public Guid Id { get; set; }
     public string Name { get; set; } = string.Empty;
     public string Description { get; set; } = string.Empty;
+
+    public DeletedSubCategoryNotification()
+    {
+        Id = Guid.NewGuid();
+    }
 
     public DeletedSubCategoryNotification(Guid id, string name, string description)
     {

--- a/src/EChamado/Server/EChamado.Server.Application/UseCases/Categories/Notifications/UpdatedCategoryNotification.cs
+++ b/src/EChamado/Server/EChamado.Server.Application/UseCases/Categories/Notifications/UpdatedCategoryNotification.cs
@@ -1,13 +1,18 @@
-using MediatR;
+using Paramore.Brighter;
 using System.Text.Json;
 
 namespace EChamado.Server.Application.UseCases.Categories.Notifications;
 
-public class UpdatedCategoryNotification : INotification
+public class UpdatedCategoryNotification : IRequest
 {
     public Guid Id { get; set; }
     public string Name { get; set; } = string.Empty;
     public string Description { get; set; } = string.Empty;
+
+    public UpdatedCategoryNotification()
+    {
+        Id = Guid.NewGuid();
+    }
 
     public UpdatedCategoryNotification(Guid id, string name, string description)
     {

--- a/src/EChamado/Server/EChamado.Server.Application/UseCases/Categories/Notifications/UpdatedSubCategoryNotification.cs
+++ b/src/EChamado/Server/EChamado.Server.Application/UseCases/Categories/Notifications/UpdatedSubCategoryNotification.cs
@@ -1,13 +1,18 @@
-using MediatR;
+using Paramore.Brighter;
 using System.Text.Json;
 
 namespace EChamado.Server.Application.UseCases.Categories.Notifications;
 
-public class UpdatedSubCategoryNotification : INotification
+public class UpdatedSubCategoryNotification : IRequest
 {
     public Guid Id { get; set; }
     public string Name { get; set; } = string.Empty;
     public string Description { get; set; } = string.Empty;
+
+    public UpdatedSubCategoryNotification()
+    {
+        Id = Guid.NewGuid();
+    }
 
     public UpdatedSubCategoryNotification(Guid id, string name, string description)
     {

--- a/src/EChamado/Server/EChamado.Server.Application/UseCases/Categories/Queries/GetCategoryByIdQuery.cs
+++ b/src/EChamado/Server/EChamado.Server.Application/UseCases/Categories/Queries/GetCategoryByIdQuery.cs
@@ -1,7 +1,19 @@
+using EChamado.Server.Application.Common.Messaging;
 using EChamado.Server.Application.UseCases.Categories.ViewModels;
 using EChamado.Shared.Responses;
-using MediatR;
 
 namespace EChamado.Server.Application.UseCases.Categories.Queries;
 
-public record GetCategoryByIdQuery(Guid CategoryId) : IRequest<BaseResult<CategoryViewModel>>;
+public class GetCategoryByIdQuery : BrighterRequest<BaseResult<CategoryViewModel>>
+{
+    public Guid CategoryId { get; set; }
+
+    public GetCategoryByIdQuery()
+    {
+    }
+
+    public GetCategoryByIdQuery(Guid categoryId)
+    {
+        CategoryId = categoryId;
+    }
+}

--- a/src/EChamado/Server/EChamado.Server.Application/UseCases/Categories/Queries/GetCategoryByIdQueryHandler.cs
+++ b/src/EChamado/Server/EChamado.Server.Application/UseCases/Categories/Queries/GetCategoryByIdQueryHandler.cs
@@ -2,24 +2,24 @@ using EChamado.Server.Application.UseCases.Categories.ViewModels;
 using EChamado.Server.Domain.Exceptions;
 using EChamado.Server.Domain.Repositories;
 using EChamado.Shared.Responses;
-using MediatR;
 using Microsoft.Extensions.Logging;
+using Paramore.Brighter;
 
 namespace EChamado.Server.Application.UseCases.Categories.Queries;
 
 public class GetCategoryByIdQueryHandler(
     IUnitOfWork unitOfWork,
     ILogger<GetCategoryByIdQueryHandler> logger) :
-    IRequestHandler<GetCategoryByIdQuery, BaseResult<CategoryViewModel>>
+    RequestHandlerAsync<GetCategoryByIdQuery>
 {
-    public async Task<BaseResult<CategoryViewModel>> Handle(GetCategoryByIdQuery request, CancellationToken cancellationToken)
+    public override async Task<GetCategoryByIdQuery> HandleAsync(GetCategoryByIdQuery query, CancellationToken cancellationToken = default)
     {
-        var category = await unitOfWork.Categories.GetByIdAsync(request.CategoryId, cancellationToken);
+        var category = await unitOfWork.Categories.GetByIdAsync(query.CategoryId, cancellationToken);
 
         if (category == null)
         {
-            logger.LogError("Category {CategoryId} not found", request.CategoryId);
-            throw new NotFoundException($"Category {request.CategoryId} not found");
+            logger.LogError("Category {CategoryId} not found", query.CategoryId);
+            throw new NotFoundException($"Category {query.CategoryId} not found");
         }
 
         var viewModel = new CategoryViewModel(
@@ -34,8 +34,10 @@ public class GetCategoryByIdQueryHandler(
             )).ToList()
         );
 
-        logger.LogInformation("Category {CategoryId} retrieved successfully", request.CategoryId);
+        logger.LogInformation("Category {CategoryId} retrieved successfully", query.CategoryId);
 
-        return new BaseResult<CategoryViewModel>(viewModel);
+        query.Result = new BaseResult<CategoryViewModel>(viewModel);
+
+        return await base.HandleAsync(query, cancellationToken);
     }
 }

--- a/src/EChamado/Server/EChamado.Server.Application/UseCases/Categories/Queries/SearchCategoriesQuery.cs
+++ b/src/EChamado/Server/EChamado.Server.Application/UseCases/Categories/Queries/SearchCategoriesQuery.cs
@@ -1,11 +1,11 @@
+using EChamado.Server.Application.Common.Messaging;
 using EChamado.Server.Application.UseCases.Categories.ViewModels;
 using EChamado.Shared.Responses;
 using EChamado.Shared.ViewModels;
-using MediatR;
 
 namespace EChamado.Server.Application.UseCases.Categories.Queries;
 
-public class SearchCategoriesQuery : BaseSearch, IRequest<BaseResultList<CategoryViewModel>>
+public class SearchCategoriesQuery : BaseSearch, BrighterRequest<BaseResultList<CategoryViewModel>>
 {
     public string Name { get; set; } = string.Empty;
     public string Description { get; set; } = string.Empty;

--- a/src/EChamado/Server/EChamado.Server.Application/UseCases/Categories/Queries/SearchCategoriesQueryHandler.cs
+++ b/src/EChamado/Server/EChamado.Server.Application/UseCases/Categories/Queries/SearchCategoriesQueryHandler.cs
@@ -3,54 +3,54 @@ using EChamado.Server.Domain.Domains.Orders.Entities;
 using EChamado.Server.Domain.Repositories;
 using EChamado.Shared.Responses;
 using LinqKit;
-using MediatR;
+using Paramore.Brighter;
 using System.Linq.Expressions;
 
 namespace EChamado.Server.Application.UseCases.Categories.Queries;
 
 public class SearchCategoriesQueryHandler(IUnitOfWork unitOfWork) :
-    IRequestHandler<SearchCategoriesQuery, BaseResultList<CategoryViewModel>>
+    RequestHandlerAsync<SearchCategoriesQuery>
 {
-    public async Task<BaseResultList<CategoryViewModel>> Handle(
-        SearchCategoriesQuery request,
-        CancellationToken cancellationToken)
+    public override async Task<SearchCategoriesQuery> HandleAsync(
+        SearchCategoriesQuery query,
+        CancellationToken cancellationToken = default)
     {
         Expression<Func<Category, bool>>? filter = PredicateBuilder.New<Category>(true);
         Func<IQueryable<Category>, IOrderedQueryable<Category>>? orderBy = null;
 
-        if (!string.IsNullOrWhiteSpace(request.Name))
+        if (!string.IsNullOrWhiteSpace(query.Name))
         {
-            filter = filter.And(x => x.Name == request.Name);
+            filter = filter.And(x => x.Name == query.Name);
         }
 
-        if (!string.IsNullOrWhiteSpace(request.Description))
+        if (!string.IsNullOrWhiteSpace(query.Description))
         {
-            filter = filter.And(x => x.Description == request.Description);
+            filter = filter.And(x => x.Description == query.Description);
         }
 
-        if (request.Id != Guid.Empty)
+        if (query.Id != Guid.Empty)
         {
-            filter = filter.And(x => x.Id == request.Id);
+            filter = filter.And(x => x.Id == query.Id);
         }
 
-        if (request.CreatedAt != default)
+        if (query.CreatedAt != default)
         {
-            filter = filter.And(x => x.CreatedAt == request.CreatedAt);
+            filter = filter.And(x => x.CreatedAt == query.CreatedAt);
         }
 
-        if (request.UpdatedAt != default)
+        if (query.UpdatedAt != default)
         {
-            filter = filter.And(x => x.UpdatedAt == request.UpdatedAt);
+            filter = filter.And(x => x.UpdatedAt == query.UpdatedAt);
         }
 
-        if (request.DeletedAt != new DateTime())
+        if (query.DeletedAt != new DateTime())
         {
-            filter = filter.And(x => x.DeletedAt == request.DeletedAt);
+            filter = filter.And(x => x.DeletedAt == query.DeletedAt);
         }
 
-        if (!string.IsNullOrWhiteSpace(request.Order))
+        if (!string.IsNullOrWhiteSpace(query.Order))
         {
-            switch (request.Order)
+            switch (query.Order)
             {
                 case "Id":
                     orderBy = x => x.OrderBy(n => n.Id);
@@ -86,8 +86,8 @@ public class SearchCategoriesQueryHandler(IUnitOfWork unitOfWork) :
             .SearchAsync(
                 filter,
                 orderBy,
-                request.PageSize,
-                request.PageIndex);
+                query.PageSize,
+                query.PageIndex);
 
         var items = result.Data.Select(c => new CategoryViewModel(
             c.Id,
@@ -101,6 +101,8 @@ public class SearchCategoriesQueryHandler(IUnitOfWork unitOfWork) :
             )).ToList()
         )).ToList();
 
-        return new BaseResultList<CategoryViewModel>(items, result.PagedResult);
+        query.Result = new BaseResultList<CategoryViewModel>(items, result.PagedResult);
+
+        return await base.HandleAsync(query, cancellationToken);
     }
 }

--- a/src/EChamado/Server/EChamado.Server.Application/UseCases/Comments/Commands/CreateCommentCommand.cs
+++ b/src/EChamado/Server/EChamado.Server.Application/UseCases/Comments/Commands/CreateCommentCommand.cs
@@ -1,11 +1,24 @@
+using EChamado.Server.Application.Common.Messaging;
 using EChamado.Shared.Responses;
-using MediatR;
 
 namespace EChamado.Server.Application.UseCases.Comments.Commands;
 
-public record CreateCommentCommand(
-    string Text,
-    Guid OrderId,
-    Guid UserId,
-    string UserEmail
-) : IRequest<BaseResult<Guid>>;
+public class CreateCommentCommand : BrighterRequest<BaseResult<Guid>>
+{
+    public string Text { get; set; } = string.Empty;
+    public Guid OrderId { get; set; } = default!;
+    public Guid UserId { get; set; } = default!;
+    public string UserEmail { get; set; } = string.Empty;
+
+    public CreateCommentCommand()
+    {
+    }
+
+    public CreateCommentCommand(string text, Guid orderId, Guid userId, string userEmail)
+    {
+        Text = text;
+        OrderId = orderId;
+        UserId = userId;
+        UserEmail = userEmail;
+    }
+}

--- a/src/EChamado/Server/EChamado.Server.Application/UseCases/Comments/Commands/DeleteCommentCommand.cs
+++ b/src/EChamado/Server/EChamado.Server.Application/UseCases/Comments/Commands/DeleteCommentCommand.cs
@@ -1,6 +1,18 @@
+using EChamado.Server.Application.Common.Messaging;
 using EChamado.Shared.Responses;
-using MediatR;
 
 namespace EChamado.Server.Application.UseCases.Comments.Commands;
 
-public record DeleteCommentCommand(Guid CommentId) : IRequest<BaseResult>;
+public class DeleteCommentCommand : BrighterRequest<BaseResult>
+{
+    public Guid CommentId { get; set; } = default!;
+
+    public DeleteCommentCommand()
+    {
+    }
+
+    public DeleteCommentCommand(Guid commentId)
+    {
+        CommentId = commentId;
+    }
+}

--- a/src/EChamado/Server/EChamado.Server.Application/UseCases/Comments/Notifications/CreatedCommentNotification.cs
+++ b/src/EChamado/Server/EChamado.Server.Application/UseCases/Comments/Notifications/CreatedCommentNotification.cs
@@ -1,11 +1,32 @@
-using MediatR;
+using Paramore.Brighter;
+using System.Text.Json;
 
 namespace EChamado.Server.Application.UseCases.Comments.Notifications;
 
-public record CreatedCommentNotification(
-    Guid Id,
-    string Text,
-    Guid OrderId,
-    Guid UserId,
-    string UserEmail
-) : INotification;
+public class CreatedCommentNotification : IRequest
+{
+    public Guid Id { get; set; }
+    public string Text { get; set; } = string.Empty;
+    public Guid OrderId { get; set; }
+    public Guid UserId { get; set; }
+    public string UserEmail { get; set; } = string.Empty;
+
+    public CreatedCommentNotification()
+    {
+        Id = Guid.NewGuid();
+    }
+
+    public CreatedCommentNotification(Guid id, string text, Guid orderId, Guid userId, string userEmail)
+    {
+        Id = id;
+        Text = text;
+        OrderId = orderId;
+        UserId = userId;
+        UserEmail = userEmail;
+    }
+
+    public override string? ToString()
+    {
+        return JsonSerializer.Serialize(this);
+    }
+}

--- a/src/EChamado/Server/EChamado.Server.Application/UseCases/Comments/Notifications/DeletedCommentNotification.cs
+++ b/src/EChamado/Server/EChamado.Server.Application/UseCases/Comments/Notifications/DeletedCommentNotification.cs
@@ -1,8 +1,26 @@
-using MediatR;
+using Paramore.Brighter;
+using System.Text.Json;
 
 namespace EChamado.Server.Application.UseCases.Comments.Notifications;
 
-public record DeletedCommentNotification(
-    Guid Id,
-    Guid OrderId
-) : INotification;
+public class DeletedCommentNotification : IRequest
+{
+    public Guid Id { get; set; }
+    public Guid OrderId { get; set; }
+
+    public DeletedCommentNotification()
+    {
+        Id = Guid.NewGuid();
+    }
+
+    public DeletedCommentNotification(Guid id, Guid orderId)
+    {
+        Id = id;
+        OrderId = orderId;
+    }
+
+    public override string? ToString()
+    {
+        return JsonSerializer.Serialize(this);
+    }
+}

--- a/src/EChamado/Server/EChamado.Server.Application/UseCases/Comments/Queries/GetCommentsByOrderIdQuery.cs
+++ b/src/EChamado/Server/EChamado.Server.Application/UseCases/Comments/Queries/GetCommentsByOrderIdQuery.cs
@@ -1,7 +1,19 @@
+using EChamado.Server.Application.Common.Messaging;
 using EChamado.Server.Application.UseCases.Comments.ViewModels;
 using EChamado.Shared.Responses;
-using MediatR;
 
 namespace EChamado.Server.Application.UseCases.Comments.Queries;
 
-public record GetCommentsByOrderIdQuery(Guid OrderId) : IRequest<BaseResultList<CommentViewModel>>;
+public class GetCommentsByOrderIdQuery : BrighterRequest<BaseResultList<CommentViewModel>>
+{
+    public Guid OrderId { get; set; }
+
+    public GetCommentsByOrderIdQuery()
+    {
+    }
+
+    public GetCommentsByOrderIdQuery(Guid orderId)
+    {
+        OrderId = orderId;
+    }
+}

--- a/src/EChamado/Server/EChamado.Server.Application/UseCases/Comments/Queries/GetCommentsByOrderIdQueryHandler.cs
+++ b/src/EChamado/Server/EChamado.Server.Application/UseCases/Comments/Queries/GetCommentsByOrderIdQueryHandler.cs
@@ -1,18 +1,18 @@
 using EChamado.Server.Application.UseCases.Comments.ViewModels;
 using EChamado.Server.Domain.Repositories;
 using EChamado.Shared.Responses;
-using MediatR;
+using Paramore.Brighter;
 
 namespace EChamado.Server.Application.UseCases.Comments.Queries;
 
 public class GetCommentsByOrderIdQueryHandler(IUnitOfWork unitOfWork) :
-    IRequestHandler<GetCommentsByOrderIdQuery, BaseResultList<CommentViewModel>>
+    RequestHandlerAsync<GetCommentsByOrderIdQuery>
 {
-    public async Task<BaseResultList<CommentViewModel>> Handle(
-        GetCommentsByOrderIdQuery request,
-        CancellationToken cancellationToken)
+    public override async Task<GetCommentsByOrderIdQuery> HandleAsync(
+        GetCommentsByOrderIdQuery query,
+        CancellationToken cancellationToken = default)
     {
-        var comments = await unitOfWork.Comments.GetByOrderIdAsync(request.OrderId, cancellationToken);
+        var comments = await unitOfWork.Comments.GetByOrderIdAsync(query.OrderId, cancellationToken);
 
         var items = comments.Select(c => new CommentViewModel(
             c.Id,
@@ -23,6 +23,8 @@ public class GetCommentsByOrderIdQueryHandler(IUnitOfWork unitOfWork) :
             c.CreatedAt
         )).ToList();
 
-        return new BaseResultList<CommentViewModel>(items, new PagedResult(items.Count, 1, items.Count));
+        query.Result = new BaseResultList<CommentViewModel>(items, new PagedResult(items.Count, 1, items.Count));
+
+        return await base.HandleAsync(query, cancellationToken);
     }
 }

--- a/src/EChamado/Server/EChamado.Server.Application/UseCases/Departments/Commands/CreateDepartmentCommand.cs
+++ b/src/EChamado/Server/EChamado.Server.Application/UseCases/Departments/Commands/CreateDepartmentCommand.cs
@@ -1,10 +1,20 @@
-﻿using EChamado.Shared.Responses;
-using MediatR;
+﻿using EChamado.Server.Application.Common.Messaging;
+using EChamado.Shared.Responses;
 
 namespace EChamado.Server.Application.UseCases.Departments.Commands;
 
-public class CreateDepartmentCommand : IRequest<BaseResult<Guid>>
+public class CreateDepartmentCommand : BrighterRequest<BaseResult<Guid>>
 {
-    public required string Name { get; set; }
-    public required string Description { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public string Description { get; set; } = string.Empty;
+
+    public CreateDepartmentCommand()
+    {
+    }
+
+    public CreateDepartmentCommand(string name, string description)
+    {
+        Name = name;
+        Description = description;
+    }
 }

--- a/src/EChamado/Server/EChamado.Server.Application/UseCases/Departments/Commands/DeletesDepartmentCommand.cs
+++ b/src/EChamado/Server/EChamado.Server.Application/UseCases/Departments/Commands/DeletesDepartmentCommand.cs
@@ -1,14 +1,18 @@
-﻿using EChamado.Shared.Responses;
-using MediatR;
+﻿using EChamado.Server.Application.Common.Messaging;
+using EChamado.Shared.Responses;
 
 namespace EChamado.Server.Application.UseCases.Departments.Commands;
 
-public class DeletesDepartmentCommand : IRequest<BaseResult>
+public class DeletesDepartmentCommand : BrighterRequest<BaseResult>
 {
+    public IEnumerable<Guid> Ids { get; set; } = default!;
+
+    public DeletesDepartmentCommand()
+    {
+    }
+
     public DeletesDepartmentCommand(IEnumerable<Guid> ids)
     {
         Ids = ids;
     }
-
-    public IEnumerable<Guid> Ids { get; set; }
 }

--- a/src/EChamado/Server/EChamado.Server.Application/UseCases/Departments/Commands/DisableDepartmentCommand.cs
+++ b/src/EChamado/Server/EChamado.Server.Application/UseCases/Departments/Commands/DisableDepartmentCommand.cs
@@ -1,14 +1,18 @@
-﻿using EChamado.Shared.Responses;
-using MediatR;
+﻿using EChamado.Server.Application.Common.Messaging;
+using EChamado.Shared.Responses;
 
 namespace EChamado.Server.Application.UseCases.Departments.Commands;
 
-public class DisableDepartmentCommand : IRequest<BaseResult>
+public class DisableDepartmentCommand : BrighterRequest<BaseResult>
 {
+    public Guid Id { get; set; } = default!;
+
+    public DisableDepartmentCommand()
+    {
+    }
+
     public DisableDepartmentCommand(Guid id)
     {
         Id = id;
     }
-
-    public Guid Id { get; set; }
 }

--- a/src/EChamado/Server/EChamado.Server.Application/UseCases/Departments/Commands/Handlers/CreateDepartmentCommandHandler.cs
+++ b/src/EChamado/Server/EChamado.Server.Application/UseCases/Departments/Commands/Handlers/CreateDepartmentCommandHandler.cs
@@ -1,22 +1,25 @@
-﻿using EChamado.Server.Application.UseCases.Departments.Notifications;
+﻿using EChamado.Server.Application.Common.Behaviours;
+using EChamado.Server.Application.UseCases.Departments.Notifications;
 using EChamado.Server.Domain.Domains.Orders.Entities;
 using EChamado.Server.Domain.Exceptions;
 using EChamado.Server.Domain.Repositories;
 using EChamado.Shared.Responses;
-using MediatR;
 using Microsoft.Extensions.Logging;
+using Paramore.Brighter;
 
 namespace EChamado.Server.Application.UseCases.Departments.Commands.Handlers;
 
 public class CreateDepartmentCommandHandler(
-    IUnitOfWork unitOfWork, 
-    IMediator mediator,
-    ILogger<CreateDepartmentCommandHandler> logger) : 
-    IRequestHandler<CreateDepartmentCommand, BaseResult<Guid>>
+    IUnitOfWork unitOfWork,
+    IAmACommandProcessor commandProcessor,
+    ILogger<CreateDepartmentCommandHandler> logger) :
+    RequestHandlerAsync<CreateDepartmentCommand>
 {
-    public async Task<BaseResult<Guid>> Handle(CreateDepartmentCommand request, CancellationToken cancellationToken)
+    [RequestLogging(0, HandlerTiming.Before)]
+    [RequestValidation(1, HandlerTiming.Before)]
+    public override async Task<CreateDepartmentCommand> HandleAsync(CreateDepartmentCommand command, CancellationToken cancellationToken = default)
     {
-        var entity = Department.Create(request.Name, request.Description);
+        var entity = Department.Create(command.Name, command.Description);
 
         if (!entity.IsValid())
         {
@@ -30,8 +33,9 @@ public class CreateDepartmentCommandHandler(
 
         await unitOfWork.CommitAsync();
 
-        await mediator.Publish(new CreatedDepartmentNotification(entity.Id, entity.Name, entity.Description));
+        await commandProcessor.PublishAsync(new CreatedDepartmentNotification(entity.Id, entity.Name, entity.Description), cancellationToken: cancellationToken);
 
-        return new BaseResult<Guid>(entity.Id);
+        command.Result = new BaseResult<Guid>(entity.Id);
+        return await base.HandleAsync(command, cancellationToken);
     }
 }

--- a/src/EChamado/Server/EChamado.Server.Application/UseCases/Departments/Commands/UpdateDepartmentCommand.cs
+++ b/src/EChamado/Server/EChamado.Server.Application/UseCases/Departments/Commands/UpdateDepartmentCommand.cs
@@ -1,11 +1,22 @@
-﻿using EChamado.Shared.Responses;
-using MediatR;
+﻿using EChamado.Server.Application.Common.Messaging;
+using EChamado.Shared.Responses;
 
 namespace EChamado.Server.Application.UseCases.Departments.Commands;
 
-public class UpdateDepartmentCommand : IRequest<BaseResult>
+public class UpdateDepartmentCommand : BrighterRequest<BaseResult>
 {
-    public required Guid Id { get; set; }
-    public required string Name { get; set; }
-    public required string Description { get; set; }
+    public Guid Id { get; set; } = default!;
+    public string Name { get; set; } = string.Empty;
+    public string Description { get; set; } = string.Empty;
+
+    public UpdateDepartmentCommand()
+    {
+    }
+
+    public UpdateDepartmentCommand(Guid id, string name, string description)
+    {
+        Id = id;
+        Name = name;
+        Description = description;
+    }
 }

--- a/src/EChamado/Server/EChamado.Server.Application/UseCases/Departments/Commands/UpdateStatusDepartmentCommand.cs
+++ b/src/EChamado/Server/EChamado.Server.Application/UseCases/Departments/Commands/UpdateStatusDepartmentCommand.cs
@@ -1,11 +1,20 @@
-﻿using EChamado.Shared.Responses;
-using MediatR;
+﻿using EChamado.Server.Application.Common.Messaging;
+using EChamado.Shared.Responses;
 
 namespace EChamado.Server.Application.UseCases.Departments.Commands;
 
-public class UpdateStatusDepartmentCommand : IRequest<BaseResult>
+public class UpdateStatusDepartmentCommand : BrighterRequest<BaseResult>
 {
-    public IEnumerable<Item> Items { get; set; }
+    public IEnumerable<Item> Items { get; set; } = default!;
+
+    public UpdateStatusDepartmentCommand()
+    {
+    }
+
+    public UpdateStatusDepartmentCommand(IEnumerable<Item> items)
+    {
+        Items = items;
+    }
 }
 
 public class Item

--- a/src/EChamado/Server/EChamado.Server.Application/UseCases/Departments/Notifications/CreatedDepartmentNotification.cs
+++ b/src/EChamado/Server/EChamado.Server.Application/UseCases/Departments/Notifications/CreatedDepartmentNotification.cs
@@ -1,13 +1,18 @@
-﻿using MediatR;
+﻿using Paramore.Brighter;
 using System.Text.Json;
 
 namespace EChamado.Server.Application.UseCases.Departments.Notifications;
 
-public class CreatedDepartmentNotification : INotification
+public class CreatedDepartmentNotification : IRequest
 {
     public Guid Id { get; set; }
     public string Name { get; set; } = string.Empty;
     public string Description { get; set; } = string.Empty;
+
+    public CreatedDepartmentNotification()
+    {
+        Id = Guid.NewGuid();
+    }
 
     public CreatedDepartmentNotification(Guid id, string name, string description)
     {

--- a/src/EChamado/Server/EChamado.Server.Application/UseCases/Departments/Notifications/DeletedDepartmentNotification.cs
+++ b/src/EChamado/Server/EChamado.Server.Application/UseCases/Departments/Notifications/DeletedDepartmentNotification.cs
@@ -1,13 +1,18 @@
-﻿using MediatR;
+﻿using Paramore.Brighter;
 using System.Text.Json;
 
 namespace EChamado.Server.Application.UseCases.Departments.Notifications;
 
-public class DeletedDepartmentNotification : INotification
+public class DeletedDepartmentNotification : IRequest
 {
     public Guid Id { get; set; }
     public string Name { get; set; } = string.Empty;
     public string Description { get; set; } = string.Empty;
+
+    public DeletedDepartmentNotification()
+    {
+        Id = Guid.NewGuid();
+    }
 
     public DeletedDepartmentNotification(Guid id, string name, string description)
     {

--- a/src/EChamado/Server/EChamado.Server.Application/UseCases/Departments/Notifications/DisabledDepartmentNotification.cs
+++ b/src/EChamado/Server/EChamado.Server.Application/UseCases/Departments/Notifications/DisabledDepartmentNotification.cs
@@ -1,13 +1,18 @@
-﻿using MediatR;
+﻿using Paramore.Brighter;
 using System.Text.Json;
 
 namespace EChamado.Server.Application.UseCases.Departments.Notifications;
 
-public class DisabledDepartmentNotification : INotification
+public class DisabledDepartmentNotification : IRequest
 {
     public Guid Id { get; set; }
     public string Name { get; set; } = string.Empty;
     public string Description { get; set; } = string.Empty;
+
+    public DisabledDepartmentNotification()
+    {
+        Id = Guid.NewGuid();
+    }
 
     public DisabledDepartmentNotification(Guid id, string name, string description)
     {

--- a/src/EChamado/Server/EChamado.Server.Application/UseCases/Departments/Notifications/Handlers/DepartmentNotification.cs
+++ b/src/EChamado/Server/EChamado.Server.Application/UseCases/Departments/Notifications/Handlers/DepartmentNotification.cs
@@ -1,23 +1,19 @@
 ﻿using EChamado.Server.Infrastructure.MessageBus;
-using MediatR;
+using Paramore.Brighter;
 using Microsoft.Extensions.Logging;
 
 namespace EChamado.Server.Application.UseCases.Departments.Notifications.Handlers;
 
-public class DepartmentNotification(
+public class CreatedDepartmentNotificationHandler(
     IMessageBusClient messageBusClient,
-    ILogger<DepartmentNotification> logger) :
-    INotificationHandler<CreatedDepartmentNotification>,
-    INotificationHandler<UpdatedDepartmentNotification>,
-    INotificationHandler<DeletedDepartmentNotification>,
-    INotificationHandler<DisabledDepartmentNotification>
+    ILogger<CreatedDepartmentNotificationHandler> logger) : RequestHandlerAsync<CreatedDepartmentNotification>
 {
-    public async Task Handle(CreatedDepartmentNotification notification, CancellationToken cancellationToken)
+    public override async Task<CreatedDepartmentNotification> HandleAsync(CreatedDepartmentNotification notification, CancellationToken cancellationToken = default)
     {
         if(notification == null)
         {
             logger.LogError("CreatedDepartmentNotification is null");
-            return;
+            return await base.HandleAsync(notification, cancellationToken);
         }
 
         await messageBusClient.Publish(notification.ToString(),
@@ -27,14 +23,21 @@ public class DepartmentNotification(
             "create-departament");
 
         logger.LogInformation("CreatedDepartmentNotification: " + notification);
-    }
 
-    public async Task Handle(UpdatedDepartmentNotification notification, CancellationToken cancellationToken)
+        return await base.HandleAsync(notification, cancellationToken);
+    }
+}
+
+public class UpdatedDepartmentNotificationHandler(
+    IMessageBusClient messageBusClient,
+    ILogger<UpdatedDepartmentNotificationHandler> logger) : RequestHandlerAsync<UpdatedDepartmentNotification>
+{
+    public override async Task<UpdatedDepartmentNotification> HandleAsync(UpdatedDepartmentNotification notification, CancellationToken cancellationToken = default)
     {
         if (notification == null)
         {
             logger.LogError("UpdatedDepartmentNotification is null");
-            return;
+            return await base.HandleAsync(notification, cancellationToken);
         }
 
         await messageBusClient.Publish(notification.ToString(),
@@ -44,14 +47,21 @@ public class DepartmentNotification(
             "update-departament");
 
         logger.LogInformation("UpdatedDepartmentNotification: " + notification);
-    }
 
-    public async Task Handle(DisabledDepartmentNotification notification, CancellationToken cancellationToken)
+        return await base.HandleAsync(notification, cancellationToken);
+    }
+}
+
+public class DisabledDepartmentNotificationHandler(
+    IMessageBusClient messageBusClient,
+    ILogger<DisabledDepartmentNotificationHandler> logger) : RequestHandlerAsync<DisabledDepartmentNotification>
+{
+    public override async Task<DisabledDepartmentNotification> HandleAsync(DisabledDepartmentNotification notification, CancellationToken cancellationToken = default)
     {
         if (notification == null)
         {
             logger.LogError("DisabledDepartmentNotification is null");
-            return;
+            return await base.HandleAsync(notification, cancellationToken);
         }
 
         await messageBusClient.Publish(notification.ToString(),
@@ -61,14 +71,21 @@ public class DepartmentNotification(
             "disable-departament");
 
         logger.LogInformation("DisabledDepartmentNotification: " + notification);
-    }
 
-    public async Task Handle(DeletedDepartmentNotification notification, CancellationToken cancellationToken)
+        return await base.HandleAsync(notification, cancellationToken);
+    }
+}
+
+public class DeletedDepartmentNotificationHandler(
+    IMessageBusClient messageBusClient,
+    ILogger<DeletedDepartmentNotificationHandler> logger) : RequestHandlerAsync<DeletedDepartmentNotification>
+{
+    public override async Task<DeletedDepartmentNotification> HandleAsync(DeletedDepartmentNotification notification, CancellationToken cancellationToken = default)
     {
         if (notification == null)
         {
             logger.LogError("DeletedDepartmentNotification is null");
-            return;
+            return await base.HandleAsync(notification, cancellationToken);
         }
 
         await messageBusClient.Publish(notification.ToString(),
@@ -78,5 +95,7 @@ public class DepartmentNotification(
             "delete-departament");
 
         logger.LogInformation("DeletedDepartmentNotification: " + notification);
+
+        return await base.HandleAsync(notification, cancellationToken);
     }
 }

--- a/src/EChamado/Server/EChamado.Server.Application/UseCases/Departments/Notifications/UpdatedDepartmentNotification.cs
+++ b/src/EChamado/Server/EChamado.Server.Application/UseCases/Departments/Notifications/UpdatedDepartmentNotification.cs
@@ -1,13 +1,18 @@
-﻿using MediatR;
+﻿using Paramore.Brighter;
 using System.Text.Json;
 
 namespace EChamado.Server.Application.UseCases.Departments.Notifications;
 
-public class UpdatedDepartmentNotification : INotification
+public class UpdatedDepartmentNotification : IRequest
 {
     public Guid Id { get; set; }
     public string Name { get; set; } = string.Empty;
     public string Description { get; set; } = string.Empty;
+
+    public UpdatedDepartmentNotification()
+    {
+        Id = Guid.NewGuid();
+    }
 
     public UpdatedDepartmentNotification(Guid id, string name, string description)
     {

--- a/src/EChamado/Server/EChamado.Server.Application/UseCases/Departments/Queries/GetByIdDepartmentQuery.cs
+++ b/src/EChamado/Server/EChamado.Server.Application/UseCases/Departments/Queries/GetByIdDepartmentQuery.cs
@@ -1,12 +1,16 @@
-﻿using EChamado.Server.Application.UseCases.Departments.ViewModels;
+﻿using EChamado.Server.Application.Common.Messaging;
+using EChamado.Server.Application.UseCases.Departments.ViewModels;
 using EChamado.Shared.Responses;
-using MediatR;
 
 namespace EChamado.Server.Application.UseCases.Departments.Queries;
 
-public class GetByIdDepartmentQuery : IRequest<BaseResult<DepartmentViewModel>>
+public class GetByIdDepartmentQuery : BrighterRequest<BaseResult<DepartmentViewModel>>
 {
     public Guid Id { get; set; }
+
+    public GetByIdDepartmentQuery()
+    {
+    }
 
     public GetByIdDepartmentQuery(Guid id)
     {

--- a/src/EChamado/Server/EChamado.Server.Application/UseCases/Departments/Queries/Handlers/GetByIdDepartmentQueryHandler.cs
+++ b/src/EChamado/Server/EChamado.Server.Application/UseCases/Departments/Queries/Handlers/GetByIdDepartmentQueryHandler.cs
@@ -2,21 +2,21 @@
 using EChamado.Server.Domain.Exceptions;
 using EChamado.Server.Domain.Repositories;
 using EChamado.Shared.Responses;
-using MediatR;
+using Paramore.Brighter;
 
 namespace EChamado.Server.Application.UseCases.Departments.Queries.Handlers;
 
-public class GetByIdDepartmentQueryHandler(IUnitOfWork unitOfWork) : 
-    IRequestHandler<GetByIdDepartmentQuery, BaseResult<DepartmentViewModel>>
+public class GetByIdDepartmentQueryHandler(IUnitOfWork unitOfWork) :
+    RequestHandlerAsync<GetByIdDepartmentQuery>
 {
-    public async Task<BaseResult<DepartmentViewModel>> Handle(
-        GetByIdDepartmentQuery request, 
-        CancellationToken cancellationToken)
+    public override async Task<GetByIdDepartmentQuery> HandleAsync(
+        GetByIdDepartmentQuery query,
+        CancellationToken cancellationToken = default)
     {
-       if(request == null)
-            throw new ArgumentNullException(nameof(request));
+       if(query == null)
+            throw new ArgumentNullException(nameof(query));
 
-        var department = await unitOfWork.Departments.GetByIdAsync(request.Id);
+        var department = await unitOfWork.Departments.GetByIdAsync(query.Id);
 
         if(department == null)
             throw new NotFoundException("Not found");
@@ -29,8 +29,8 @@ public class GetByIdDepartmentQueryHandler(IUnitOfWork unitOfWork) :
             department.Name,
             department.Description);
 
-        var result = new BaseResult<DepartmentViewModel>(viewModel, true, "Obitido com sucesso");
+        query.Result = new BaseResult<DepartmentViewModel>(viewModel, true, "Obitido com sucesso");
 
-        return result;
+        return await base.HandleAsync(query, cancellationToken);
     }
 }

--- a/src/EChamado/Server/EChamado.Server.Application/UseCases/Departments/Queries/Handlers/SearchDepartmentQueryHandler.cs
+++ b/src/EChamado/Server/EChamado.Server.Application/UseCases/Departments/Queries/Handlers/SearchDepartmentQueryHandler.cs
@@ -3,54 +3,54 @@ using EChamado.Server.Domain.Domains.Orders.Entities;
 using EChamado.Server.Domain.Repositories;
 using EChamado.Shared.Responses;
 using LinqKit;
-using MediatR;
+using Paramore.Brighter;
 using System.Linq.Expressions;
 
 namespace EChamado.Server.Application.UseCases.Departments.Queries.Handlers;
 
-public class SearchDepartmentQueryHandler(IUnitOfWork unitOfWork) : 
-    IRequestHandler<SearchDepartmentQuery, BaseResultList<DepartmentViewModel>>
+public class SearchDepartmentQueryHandler(IUnitOfWork unitOfWork) :
+    RequestHandlerAsync<SearchDepartmentQuery>
 {
-    public async Task<BaseResultList<DepartmentViewModel>> Handle(
-        SearchDepartmentQuery request, 
-        CancellationToken cancellationToken)
+    public override async Task<SearchDepartmentQuery> HandleAsync(
+        SearchDepartmentQuery query,
+        CancellationToken cancellationToken = default)
     {
         Expression<Func<Department, bool>>? filter = PredicateBuilder.New<Department>(true);
         Func<IQueryable<Department>, IOrderedQueryable<Department>>? ordeBy = null;
 
-        if (!string.IsNullOrWhiteSpace(request.Name))
+        if (!string.IsNullOrWhiteSpace(query.Name))
         {
-            filter = filter.And(x => x.Name == request.Name);
+            filter = filter.And(x => x.Name == query.Name);
         }
 
-        if (!string.IsNullOrWhiteSpace(request.Description))
+        if (!string.IsNullOrWhiteSpace(query.Description))
         {
-            filter = filter.And(x => x.Description == request.Description);
+            filter = filter.And(x => x.Description == query.Description);
         }
 
-        if (request.Id != Guid.Empty)
+        if (query.Id != Guid.Empty)
         {
-            filter = filter.And(x => x.Id == request.Id);
+            filter = filter.And(x => x.Id == query.Id);
         }
 
-        if (request.CreatedAt != default)
+        if (query.CreatedAt != default)
         {
-            filter = filter.And(x => x.CreatedAt == request.CreatedAt);
+            filter = filter.And(x => x.CreatedAt == query.CreatedAt);
         }
 
-        if (request.UpdatedAt != default)
+        if (query.UpdatedAt != default)
         {
-            filter = filter.And(x => x.UpdatedAt == request.UpdatedAt);
+            filter = filter.And(x => x.UpdatedAt == query.UpdatedAt);
         }
 
-        if (request.DeletedAt != new DateTime())
+        if (query.DeletedAt != new DateTime())
         {
-            filter = filter.And(x => x.DeletedAt == request.DeletedAt);
+            filter = filter.And(x => x.DeletedAt == query.DeletedAt);
         }
 
-        if (!string.IsNullOrWhiteSpace(request.Order))
+        if (!string.IsNullOrWhiteSpace(query.Order))
         {
-            switch (request.Order)
+            switch (query.Order)
             {
                 case "Id":
                     ordeBy = x => x.OrderBy(n => n.Id);
@@ -86,10 +86,12 @@ public class SearchDepartmentQueryHandler(IUnitOfWork unitOfWork) :
           .SearchAsync(
               filter,
               ordeBy,
-              request.PageSize,
-              request.PageIndex);
+              query.PageSize,
+              query.PageIndex);
 
-        return new BaseResultList<DepartmentViewModel>(
+        query.Result = new BaseResultList<DepartmentViewModel>(
             result.Data.Select(x => DepartmentViewModel.FromEntity(x)).ToList(), result.PagedResult);
+
+        return await base.HandleAsync(query, cancellationToken);
     }
 }

--- a/src/EChamado/Server/EChamado.Server.Application/UseCases/Departments/Queries/SearchDepartmentQuery.cs
+++ b/src/EChamado/Server/EChamado.Server.Application/UseCases/Departments/Queries/SearchDepartmentQuery.cs
@@ -1,11 +1,11 @@
-﻿using EChamado.Server.Application.UseCases.Departments.ViewModels;
+﻿using EChamado.Server.Application.Common.Messaging;
+using EChamado.Server.Application.UseCases.Departments.ViewModels;
 using EChamado.Shared.Responses;
 using EChamado.Shared.ViewModels;
-using MediatR;
 
 namespace EChamado.Server.Application.UseCases.Departments.Queries;
 
-public class SearchDepartmentQuery : BaseSearch, IRequest<BaseResultList<DepartmentViewModel>>
+public class SearchDepartmentQuery : BaseSearch, BrighterRequest<BaseResultList<DepartmentViewModel>>
 {
     public string Name { get; set; } = string.Empty;
     public string Description { get; set; } = string.Empty;

--- a/src/EChamado/Server/EChamado.Server.Application/UseCases/OrderTypes/Commands/CreateOrderTypeCommand.cs
+++ b/src/EChamado/Server/EChamado.Server.Application/UseCases/OrderTypes/Commands/CreateOrderTypeCommand.cs
@@ -1,9 +1,20 @@
+using EChamado.Server.Application.Common.Messaging;
 using EChamado.Shared.Responses;
-using MediatR;
 
 namespace EChamado.Server.Application.UseCases.OrderTypes.Commands;
 
-public record CreateOrderTypeCommand(
-    string Name,
-    string Description
-) : IRequest<BaseResult<Guid>>;
+public class CreateOrderTypeCommand : BrighterRequest<BaseResult<Guid>>
+{
+    public string Name { get; set; } = string.Empty;
+    public string Description { get; set; } = string.Empty;
+
+    public CreateOrderTypeCommand()
+    {
+    }
+
+    public CreateOrderTypeCommand(string name, string description)
+    {
+        Name = name;
+        Description = description;
+    }
+}

--- a/src/EChamado/Server/EChamado.Server.Application/UseCases/OrderTypes/Commands/DeleteOrderTypeCommand.cs
+++ b/src/EChamado/Server/EChamado.Server.Application/UseCases/OrderTypes/Commands/DeleteOrderTypeCommand.cs
@@ -1,6 +1,18 @@
+using EChamado.Server.Application.Common.Messaging;
 using EChamado.Shared.Responses;
-using MediatR;
 
 namespace EChamado.Server.Application.UseCases.OrderTypes.Commands;
 
-public record DeleteOrderTypeCommand(Guid OrderTypeId) : IRequest<BaseResult>;
+public class DeleteOrderTypeCommand : BrighterRequest<BaseResult>
+{
+    public Guid OrderTypeId { get; set; } = default!;
+
+    public DeleteOrderTypeCommand()
+    {
+    }
+
+    public DeleteOrderTypeCommand(Guid orderTypeId)
+    {
+        OrderTypeId = orderTypeId;
+    }
+}

--- a/src/EChamado/Server/EChamado.Server.Application/UseCases/OrderTypes/Commands/UpdateOrderTypeCommand.cs
+++ b/src/EChamado/Server/EChamado.Server.Application/UseCases/OrderTypes/Commands/UpdateOrderTypeCommand.cs
@@ -1,10 +1,22 @@
+using EChamado.Server.Application.Common.Messaging;
 using EChamado.Shared.Responses;
-using MediatR;
 
 namespace EChamado.Server.Application.UseCases.OrderTypes.Commands;
 
-public record UpdateOrderTypeCommand(
-    Guid Id,
-    string Name,
-    string Description
-) : IRequest<BaseResult>;
+public class UpdateOrderTypeCommand : BrighterRequest<BaseResult>
+{
+    public Guid Id { get; set; } = default!;
+    public string Name { get; set; } = string.Empty;
+    public string Description { get; set; } = string.Empty;
+
+    public UpdateOrderTypeCommand()
+    {
+    }
+
+    public UpdateOrderTypeCommand(Guid id, string name, string description)
+    {
+        Id = id;
+        Name = name;
+        Description = description;
+    }
+}

--- a/src/EChamado/Server/EChamado.Server.Application/UseCases/OrderTypes/Notifications/CreatedOrderTypeNotification.cs
+++ b/src/EChamado/Server/EChamado.Server.Application/UseCases/OrderTypes/Notifications/CreatedOrderTypeNotification.cs
@@ -1,13 +1,18 @@
-using MediatR;
+using Paramore.Brighter;
 using System.Text.Json;
 
 namespace EChamado.Server.Application.UseCases.OrderTypes.Notifications;
 
-public class CreatedOrderTypeNotification : INotification
+public class CreatedOrderTypeNotification : IRequest
 {
     public Guid Id { get; set; }
     public string Name { get; set; } = string.Empty;
     public string Description { get; set; } = string.Empty;
+
+    public CreatedOrderTypeNotification()
+    {
+        Id = Guid.NewGuid();
+    }
 
     public CreatedOrderTypeNotification(Guid id, string name, string description)
     {

--- a/src/EChamado/Server/EChamado.Server.Application/UseCases/OrderTypes/Notifications/DeletedOrderTypeNotification.cs
+++ b/src/EChamado/Server/EChamado.Server.Application/UseCases/OrderTypes/Notifications/DeletedOrderTypeNotification.cs
@@ -1,13 +1,18 @@
-using MediatR;
+using Paramore.Brighter;
 using System.Text.Json;
 
 namespace EChamado.Server.Application.UseCases.OrderTypes.Notifications;
 
-public class DeletedOrderTypeNotification : INotification
+public class DeletedOrderTypeNotification : IRequest
 {
     public Guid Id { get; set; }
     public string Name { get; set; } = string.Empty;
     public string Description { get; set; } = string.Empty;
+
+    public DeletedOrderTypeNotification()
+    {
+        Id = Guid.NewGuid();
+    }
 
     public DeletedOrderTypeNotification(Guid id, string name, string description)
     {

--- a/src/EChamado/Server/EChamado.Server.Application/UseCases/OrderTypes/Notifications/UpdatedOrderTypeNotification.cs
+++ b/src/EChamado/Server/EChamado.Server.Application/UseCases/OrderTypes/Notifications/UpdatedOrderTypeNotification.cs
@@ -1,13 +1,18 @@
-using MediatR;
+using Paramore.Brighter;
 using System.Text.Json;
 
 namespace EChamado.Server.Application.UseCases.OrderTypes.Notifications;
 
-public class UpdatedOrderTypeNotification : INotification
+public class UpdatedOrderTypeNotification : IRequest
 {
     public Guid Id { get; set; }
     public string Name { get; set; } = string.Empty;
     public string Description { get; set; } = string.Empty;
+
+    public UpdatedOrderTypeNotification()
+    {
+        Id = Guid.NewGuid();
+    }
 
     public UpdatedOrderTypeNotification(Guid id, string name, string description)
     {

--- a/src/EChamado/Server/EChamado.Server.Application/UseCases/OrderTypes/Queries/GetOrderTypeByIdQuery.cs
+++ b/src/EChamado/Server/EChamado.Server.Application/UseCases/OrderTypes/Queries/GetOrderTypeByIdQuery.cs
@@ -1,7 +1,19 @@
+using EChamado.Server.Application.Common.Messaging;
 using EChamado.Server.Application.UseCases.OrderTypes.ViewModels;
 using EChamado.Shared.Responses;
-using MediatR;
 
 namespace EChamado.Server.Application.UseCases.OrderTypes.Queries;
 
-public record GetOrderTypeByIdQuery(Guid OrderTypeId) : IRequest<BaseResult<OrderTypeViewModel>>;
+public class GetOrderTypeByIdQuery : BrighterRequest<BaseResult<OrderTypeViewModel>>
+{
+    public Guid OrderTypeId { get; set; }
+
+    public GetOrderTypeByIdQuery()
+    {
+    }
+
+    public GetOrderTypeByIdQuery(Guid orderTypeId)
+    {
+        OrderTypeId = orderTypeId;
+    }
+}

--- a/src/EChamado/Server/EChamado.Server.Application/UseCases/OrderTypes/Queries/SearchOrderTypesQuery.cs
+++ b/src/EChamado/Server/EChamado.Server.Application/UseCases/OrderTypes/Queries/SearchOrderTypesQuery.cs
@@ -1,11 +1,11 @@
+using EChamado.Server.Application.Common.Messaging;
 using EChamado.Server.Application.UseCases.OrderTypes.ViewModels;
 using EChamado.Shared.Responses;
 using EChamado.Shared.ViewModels;
-using MediatR;
 
 namespace EChamado.Server.Application.UseCases.OrderTypes.Queries;
 
-public class SearchOrderTypesQuery : BaseSearch, IRequest<BaseResultList<OrderTypeViewModel>>
+public class SearchOrderTypesQuery : BaseSearch, BrighterRequest<BaseResultList<OrderTypeViewModel>>
 {
     public string Name { get; set; } = string.Empty;
     public string Description { get; set; } = string.Empty;

--- a/src/EChamado/Server/EChamado.Server.Application/UseCases/OrderTypes/Queries/SearchOrderTypesQueryHandler.cs
+++ b/src/EChamado/Server/EChamado.Server.Application/UseCases/OrderTypes/Queries/SearchOrderTypesQueryHandler.cs
@@ -3,54 +3,54 @@ using EChamado.Server.Domain.Domains.Orders.Entities;
 using EChamado.Server.Domain.Repositories;
 using EChamado.Shared.Responses;
 using LinqKit;
-using MediatR;
+using Paramore.Brighter;
 using System.Linq.Expressions;
 
 namespace EChamado.Server.Application.UseCases.OrderTypes.Queries;
 
 public class SearchOrderTypesQueryHandler(IUnitOfWork unitOfWork) :
-    IRequestHandler<SearchOrderTypesQuery, BaseResultList<OrderTypeViewModel>>
+    RequestHandlerAsync<SearchOrderTypesQuery>
 {
-    public async Task<BaseResultList<OrderTypeViewModel>> Handle(
-        SearchOrderTypesQuery request,
-        CancellationToken cancellationToken)
+    public override async Task<SearchOrderTypesQuery> HandleAsync(
+        SearchOrderTypesQuery query,
+        CancellationToken cancellationToken = default)
     {
         Expression<Func<OrderType, bool>>? filter = PredicateBuilder.New<OrderType>(true);
         Func<IQueryable<OrderType>, IOrderedQueryable<OrderType>>? orderBy = null;
 
-        if (!string.IsNullOrWhiteSpace(request.Name))
+        if (!string.IsNullOrWhiteSpace(query.Name))
         {
-            filter = filter.And(x => x.Name == request.Name);
+            filter = filter.And(x => x.Name == query.Name);
         }
 
-        if (!string.IsNullOrWhiteSpace(request.Description))
+        if (!string.IsNullOrWhiteSpace(query.Description))
         {
-            filter = filter.And(x => x.Description == request.Description);
+            filter = filter.And(x => x.Description == query.Description);
         }
 
-        if (request.Id != Guid.Empty)
+        if (query.Id != Guid.Empty)
         {
-            filter = filter.And(x => x.Id == request.Id);
+            filter = filter.And(x => x.Id == query.Id);
         }
 
-        if (request.CreatedAt != default)
+        if (query.CreatedAt != default)
         {
-            filter = filter.And(x => x.CreatedAt == request.CreatedAt);
+            filter = filter.And(x => x.CreatedAt == query.CreatedAt);
         }
 
-        if (request.UpdatedAt != default)
+        if (query.UpdatedAt != default)
         {
-            filter = filter.And(x => x.UpdatedAt == request.UpdatedAt);
+            filter = filter.And(x => x.UpdatedAt == query.UpdatedAt);
         }
 
-        if (request.DeletedAt != new DateTime())
+        if (query.DeletedAt != new DateTime())
         {
-            filter = filter.And(x => x.DeletedAt == request.DeletedAt);
+            filter = filter.And(x => x.DeletedAt == query.DeletedAt);
         }
 
-        if (!string.IsNullOrWhiteSpace(request.Order))
+        if (!string.IsNullOrWhiteSpace(query.Order))
         {
-            switch (request.Order)
+            switch (query.Order)
             {
                 case "Id":
                     orderBy = x => x.OrderBy(n => n.Id);
@@ -86,8 +86,8 @@ public class SearchOrderTypesQueryHandler(IUnitOfWork unitOfWork) :
             .SearchAsync(
                 filter,
                 orderBy,
-                request.PageSize,
-                request.PageIndex);
+                query.PageSize,
+                query.PageIndex);
 
         var items = result.Data.Select(ot => new OrderTypeViewModel(
             ot.Id,
@@ -95,6 +95,8 @@ public class SearchOrderTypesQueryHandler(IUnitOfWork unitOfWork) :
             ot.Description
         )).ToList();
 
-        return new BaseResultList<OrderTypeViewModel>(items, result.PagedResult);
+        query.Result = new BaseResultList<OrderTypeViewModel>(items, result.PagedResult);
+
+        return await base.HandleAsync(query, cancellationToken);
     }
 }

--- a/src/EChamado/Server/EChamado.Server.Application/UseCases/Orders/Commands/AssignOrderCommand.cs
+++ b/src/EChamado/Server/EChamado.Server.Application/UseCases/Orders/Commands/AssignOrderCommand.cs
@@ -1,9 +1,20 @@
+using EChamado.Server.Application.Common.Messaging;
 using EChamado.Shared.Responses;
-using MediatR;
 
 namespace EChamado.Server.Application.UseCases.Orders.Commands;
 
-public record AssignOrderCommand(
-    Guid OrderId,
-    Guid AssignedToUserId
-) : IRequest<BaseResult>;
+public class AssignOrderCommand : BrighterRequest<BaseResult>
+{
+    public Guid OrderId { get; set; } = default!;
+    public Guid AssignedToUserId { get; set; } = default!;
+
+    public AssignOrderCommand()
+    {
+    }
+
+    public AssignOrderCommand(Guid orderId, Guid assignedToUserId)
+    {
+        OrderId = orderId;
+        AssignedToUserId = assignedToUserId;
+    }
+}

--- a/src/EChamado/Server/EChamado.Server.Application/UseCases/Orders/Commands/ChangeStatusOrderCommand.cs
+++ b/src/EChamado/Server/EChamado.Server.Application/UseCases/Orders/Commands/ChangeStatusOrderCommand.cs
@@ -1,9 +1,20 @@
+using EChamado.Server.Application.Common.Messaging;
 using EChamado.Shared.Responses;
-using MediatR;
 
 namespace EChamado.Server.Application.UseCases.Orders.Commands;
 
-public record ChangeStatusOrderCommand(
-    Guid OrderId,
-    Guid StatusId
-) : IRequest<BaseResult>;
+public class ChangeStatusOrderCommand : BrighterRequest<BaseResult>
+{
+    public Guid OrderId { get; set; } = default!;
+    public Guid StatusId { get; set; } = default!;
+
+    public ChangeStatusOrderCommand()
+    {
+    }
+
+    public ChangeStatusOrderCommand(Guid orderId, Guid statusId)
+    {
+        OrderId = orderId;
+        StatusId = statusId;
+    }
+}

--- a/src/EChamado/Server/EChamado.Server.Application/UseCases/Orders/Commands/CloseOrderCommand.cs
+++ b/src/EChamado/Server/EChamado.Server.Application/UseCases/Orders/Commands/CloseOrderCommand.cs
@@ -1,9 +1,20 @@
+using EChamado.Server.Application.Common.Messaging;
 using EChamado.Shared.Responses;
-using MediatR;
 
 namespace EChamado.Server.Application.UseCases.Orders.Commands;
 
-public record CloseOrderCommand(
-    Guid OrderId,
-    int? Evaluation
-) : IRequest<BaseResult>;
+public class CloseOrderCommand : BrighterRequest<BaseResult>
+{
+    public Guid OrderId { get; set; } = default!;
+    public int? Evaluation { get; set; }
+
+    public CloseOrderCommand()
+    {
+    }
+
+    public CloseOrderCommand(Guid orderId, int? evaluation)
+    {
+        OrderId = orderId;
+        Evaluation = evaluation;
+    }
+}

--- a/src/EChamado/Server/EChamado.Server.Application/UseCases/Orders/Commands/CloseOrderCommandHandler.cs
+++ b/src/EChamado/Server/EChamado.Server.Application/UseCases/Orders/Commands/CloseOrderCommandHandler.cs
@@ -1,33 +1,36 @@
+using EChamado.Server.Application.Common.Behaviours;
 using EChamado.Server.Domain.Exceptions;
 using EChamado.Server.Domain.Repositories;
 using EChamado.Shared.Responses;
-using MediatR;
 using Microsoft.Extensions.Logging;
+using Paramore.Brighter;
 
 namespace EChamado.Server.Application.UseCases.Orders.Commands;
 
 public class CloseOrderCommandHandler(
     IUnitOfWork unitOfWork,
     ILogger<CloseOrderCommandHandler> logger) :
-    IRequestHandler<CloseOrderCommand, BaseResult>
+    RequestHandlerAsync<CloseOrderCommand>
 {
-    public async Task<BaseResult> Handle(CloseOrderCommand request, CancellationToken cancellationToken)
+    [RequestLogging(0, HandlerTiming.Before)]
+    [RequestValidation(1, HandlerTiming.Before)]
+    public override async Task<CloseOrderCommand> HandleAsync(CloseOrderCommand command, CancellationToken cancellationToken = default)
     {
-        var order = await unitOfWork.Orders.GetByIdAsync(request.OrderId, cancellationToken);
+        var order = await unitOfWork.Orders.GetByIdAsync(command.OrderId, cancellationToken);
 
         if (order == null)
         {
-            logger.LogError("Order {OrderId} not found", request.OrderId);
-            throw new NotFoundException($"Order {request.OrderId} not found");
+            logger.LogError("Order {OrderId} not found", command.OrderId);
+            throw new NotFoundException($"Order {command.OrderId} not found");
         }
 
         if (order.ClosingDate.HasValue)
         {
-            logger.LogWarning("Order {OrderId} is already closed", request.OrderId);
+            logger.LogWarning("Order {OrderId} is already closed", command.OrderId);
             throw new ValidationException("Order is already closed");
         }
 
-        order.Close(request.Evaluation ?? 0);
+        order.Close(command.Evaluation ?? 0);
 
         if (!order.IsValid())
         {
@@ -42,8 +45,9 @@ public class CloseOrderCommandHandler(
         await unitOfWork.CommitAsync();
 
         logger.LogInformation("Order {OrderId} closed successfully with evaluation {Evaluation}",
-            request.OrderId, request.Evaluation);
+            command.OrderId, command.Evaluation);
 
-        return new BaseResult();
+        command.Result = new BaseResult();
+        return await base.HandleAsync(command, cancellationToken);
     }
 }

--- a/src/EChamado/Server/EChamado.Server.Application/UseCases/Orders/Commands/CreateOrderCommand.cs
+++ b/src/EChamado/Server/EChamado.Server.Application/UseCases/Orders/Commands/CreateOrderCommand.cs
@@ -1,16 +1,34 @@
+using EChamado.Server.Application.Common.Messaging;
 using EChamado.Shared.Responses;
-using MediatR;
 
 namespace EChamado.Server.Application.UseCases.Orders.Commands;
 
-public record CreateOrderCommand(
-    string Title,
-    string Description,
-    Guid TypeId,
-    Guid? CategoryId,
-    Guid? SubCategoryId,
-    Guid? DepartmentId,
-    DateTime? DueDate,
-    Guid RequestingUserId,
-    string RequestingUserEmail
-) : IRequest<BaseResult<Guid>>;
+public class CreateOrderCommand : BrighterRequest<BaseResult<Guid>>
+{
+    public string Title { get; set; } = string.Empty;
+    public string Description { get; set; } = string.Empty;
+    public Guid TypeId { get; set; } = default!;
+    public Guid? CategoryId { get; set; }
+    public Guid? SubCategoryId { get; set; }
+    public Guid? DepartmentId { get; set; }
+    public DateTime? DueDate { get; set; }
+    public Guid RequestingUserId { get; set; } = default!;
+    public string RequestingUserEmail { get; set; } = string.Empty;
+
+    public CreateOrderCommand()
+    {
+    }
+
+    public CreateOrderCommand(string title, string description, Guid typeId, Guid? categoryId, Guid? subCategoryId, Guid? departmentId, DateTime? dueDate, Guid requestingUserId, string requestingUserEmail)
+    {
+        Title = title;
+        Description = description;
+        TypeId = typeId;
+        CategoryId = categoryId;
+        SubCategoryId = subCategoryId;
+        DepartmentId = departmentId;
+        DueDate = dueDate;
+        RequestingUserId = requestingUserId;
+        RequestingUserEmail = requestingUserEmail;
+    }
+}

--- a/src/EChamado/Server/EChamado.Server.Application/UseCases/Orders/Commands/UpdateOrderCommand.cs
+++ b/src/EChamado/Server/EChamado.Server.Application/UseCases/Orders/Commands/UpdateOrderCommand.cs
@@ -1,15 +1,32 @@
+using EChamado.Server.Application.Common.Messaging;
 using EChamado.Shared.Responses;
-using MediatR;
 
 namespace EChamado.Server.Application.UseCases.Orders.Commands;
 
-public record UpdateOrderCommand(
-    Guid Id,
-    string Title,
-    string Description,
-    Guid TypeId,
-    Guid? CategoryId,
-    Guid? SubCategoryId,
-    Guid? DepartmentId,
-    DateTime? DueDate
-) : IRequest<BaseResult>;
+public class UpdateOrderCommand : BrighterRequest<BaseResult>
+{
+    public Guid Id { get; set; } = default!;
+    public string Title { get; set; } = string.Empty;
+    public string Description { get; set; } = string.Empty;
+    public Guid TypeId { get; set; } = default!;
+    public Guid? CategoryId { get; set; }
+    public Guid? SubCategoryId { get; set; }
+    public Guid? DepartmentId { get; set; }
+    public DateTime? DueDate { get; set; }
+
+    public UpdateOrderCommand()
+    {
+    }
+
+    public UpdateOrderCommand(Guid id, string title, string description, Guid typeId, Guid? categoryId, Guid? subCategoryId, Guid? departmentId, DateTime? dueDate)
+    {
+        Id = id;
+        Title = title;
+        Description = description;
+        TypeId = typeId;
+        CategoryId = categoryId;
+        SubCategoryId = subCategoryId;
+        DepartmentId = departmentId;
+        DueDate = dueDate;
+    }
+}

--- a/src/EChamado/Server/EChamado.Server.Application/UseCases/Orders/Queries/GetOrderByIdQuery.cs
+++ b/src/EChamado/Server/EChamado.Server.Application/UseCases/Orders/Queries/GetOrderByIdQuery.cs
@@ -1,7 +1,19 @@
+using EChamado.Server.Application.Common.Messaging;
 using EChamado.Server.Application.UseCases.Orders.ViewModels;
 using EChamado.Shared.Responses;
-using MediatR;
 
 namespace EChamado.Server.Application.UseCases.Orders.Queries;
 
-public record GetOrderByIdQuery(Guid OrderId) : IRequest<BaseResult<OrderViewModel>>;
+public class GetOrderByIdQuery : BrighterRequest<BaseResult<OrderViewModel>>
+{
+    public Guid OrderId { get; set; }
+
+    public GetOrderByIdQuery()
+    {
+    }
+
+    public GetOrderByIdQuery(Guid orderId)
+    {
+        OrderId = orderId;
+    }
+}

--- a/src/EChamado/Server/EChamado.Server.Application/UseCases/Orders/Queries/SearchOrdersQuery.cs
+++ b/src/EChamado/Server/EChamado.Server.Application/UseCases/Orders/Queries/SearchOrdersQuery.cs
@@ -1,10 +1,10 @@
+using EChamado.Server.Application.Common.Messaging;
 using EChamado.Server.Application.UseCases.Orders.ViewModels;
 using EChamado.Shared.Responses;
-using MediatR;
 
 namespace EChamado.Server.Application.UseCases.Orders.Queries;
 
-public class SearchOrdersQuery : IRequest<BaseResultList<OrderListViewModel>>
+public class SearchOrdersQuery : BrighterRequest<BaseResultList<OrderListViewModel>>
 {
     public int PageNumber { get; set; } = 1;
     public int PageSize { get; set; } = 10;

--- a/src/EChamado/Server/EChamado.Server.Application/UseCases/Roles/Commands/CreateRoleCommand.cs
+++ b/src/EChamado/Server/EChamado.Server.Application/UseCases/Roles/Commands/CreateRoleCommand.cs
@@ -1,9 +1,18 @@
-﻿using EChamado.Shared.Responses;
-using MediatR;
+﻿using EChamado.Server.Application.Common.Messaging;
+using EChamado.Shared.Responses;
 
 namespace EChamado.Server.Application.UseCases.Roles.Commands;
 
-public class CreateRoleCommand : IRequest<BaseResult<Guid>>
+public class CreateRoleCommand : BrighterRequest<BaseResult<Guid>>
 {
-    public string Name { get; set; }
+    public string Name { get; set; } = string.Empty;
+
+    public CreateRoleCommand()
+    {
+    }
+
+    public CreateRoleCommand(string name)
+    {
+        Name = name;
+    }
 }

--- a/src/EChamado/Server/EChamado.Server.Application/UseCases/Roles/Commands/DeleteRoleCommand.cs
+++ b/src/EChamado/Server/EChamado.Server.Application/UseCases/Roles/Commands/DeleteRoleCommand.cs
@@ -1,14 +1,18 @@
-﻿using EChamado.Shared.Responses;
-using MediatR;
+﻿using EChamado.Server.Application.Common.Messaging;
+using EChamado.Shared.Responses;
 
 namespace EChamado.Server.Application.UseCases.Roles.Commands;
 
-public class DeleteRoleCommand : IRequest<BaseResult>
+public class DeleteRoleCommand : BrighterRequest<BaseResult>
 {
+    public Guid Id { get; set; } = default!;
+
+    public DeleteRoleCommand()
+    {
+    }
+
     public DeleteRoleCommand(Guid id)
     {
         Id = id;
     }
-
-    public Guid Id { get; set; }
 }

--- a/src/EChamado/Server/EChamado.Server.Application/UseCases/Roles/Commands/UpdateRoleCommand.cs
+++ b/src/EChamado/Server/EChamado.Server.Application/UseCases/Roles/Commands/UpdateRoleCommand.cs
@@ -1,10 +1,20 @@
-﻿using EChamado.Shared.Responses;
-using MediatR;
+﻿using EChamado.Server.Application.Common.Messaging;
+using EChamado.Shared.Responses;
 
 namespace EChamado.Server.Application.UseCases.Roles.Commands;
 
-public class UpdateRoleCommand : IRequest<BaseResult>
+public class UpdateRoleCommand : BrighterRequest<BaseResult>
 {
-    public Guid Id { get; set; }
+    public Guid Id { get; set; } = default!;
     public string Name { get; set; } = string.Empty;
+
+    public UpdateRoleCommand()
+    {
+    }
+
+    public UpdateRoleCommand(Guid id, string name)
+    {
+        Id = id;
+        Name = name;
+    }
 }

--- a/src/EChamado/Server/EChamado.Server.Application/UseCases/Roles/Queries/GetAllRolesQuery.cs
+++ b/src/EChamado/Server/EChamado.Server.Application/UseCases/Roles/Queries/GetAllRolesQuery.cs
@@ -1,9 +1,9 @@
-﻿using EChamado.Server.Application.UseCases.Roles.ViewModels;
+﻿using EChamado.Server.Application.Common.Messaging;
+using EChamado.Server.Application.UseCases.Roles.ViewModels;
 using EChamado.Shared.Responses;
-using MediatR;
 
 namespace EChamado.Server.Application.UseCases.Roles.Queries;
 
-public class GetAllRolesQuery : IRequest<BaseResultList<RolesViewModel>>
+public class GetAllRolesQuery : BrighterRequest<BaseResultList<RolesViewModel>>
 {
 }

--- a/src/EChamado/Server/EChamado.Server.Application/UseCases/Roles/Queries/GetRoleByIdQuery.cs
+++ b/src/EChamado/Server/EChamado.Server.Application/UseCases/Roles/Queries/GetRoleByIdQuery.cs
@@ -1,12 +1,17 @@
-﻿using EChamado.Server.Application.UseCases.Roles.ViewModels;
+﻿using EChamado.Server.Application.Common.Messaging;
+using EChamado.Server.Application.UseCases.Roles.ViewModels;
 using EChamado.Shared.Responses;
-using MediatR;
 
 namespace EChamado.Server.Application.UseCases.Roles.Queries;
 
-public class GetRoleByIdQuery : IRequest<BaseResult<RolesViewModel>>
+public class GetRoleByIdQuery : BrighterRequest<BaseResult<RolesViewModel>>
 {
     public Guid Id { get; set; }
+
+    public GetRoleByIdQuery()
+    {
+    }
+
     public GetRoleByIdQuery(Guid id)
     {
         Id = id;

--- a/src/EChamado/Server/EChamado.Server.Application/UseCases/Roles/Queries/GetRoleByNameQuery.cs
+++ b/src/EChamado/Server/EChamado.Server.Application/UseCases/Roles/Queries/GetRoleByNameQuery.cs
@@ -1,12 +1,17 @@
-﻿using EChamado.Server.Application.UseCases.Roles.ViewModels;
+﻿using EChamado.Server.Application.Common.Messaging;
+using EChamado.Server.Application.UseCases.Roles.ViewModels;
 using EChamado.Shared.Responses;
-using MediatR;
 
 namespace EChamado.Server.Application.UseCases.Roles.Queries;
 
-public class GetRoleByNameQuery : IRequest<BaseResult<RolesViewModel>>
+public class GetRoleByNameQuery : BrighterRequest<BaseResult<RolesViewModel>>
 {
-    public string Name { get; set; }
+    public string Name { get; set; } = string.Empty;
+
+    public GetRoleByNameQuery()
+    {
+    }
+
     public GetRoleByNameQuery(string name)
     {
         Name = name;

--- a/src/EChamado/Server/EChamado.Server.Application/UseCases/Roles/Queries/Handlers/GetAllRolesQueryHandler.cs
+++ b/src/EChamado/Server/EChamado.Server.Application/UseCases/Roles/Queries/Handlers/GetAllRolesQueryHandler.cs
@@ -1,21 +1,23 @@
 ﻿using EChamado.Server.Application.UseCases.Roles.ViewModels;
 using EChamado.Server.Domain.Services.Interface;
 using EChamado.Shared.Responses;
-using MediatR;
+using Paramore.Brighter;
 
 namespace EChamado.Server.Application.UseCases.Roles.Queries.Handlers;
 
 public class GetAllRolesQueryHandler(IRoleService roleService) :
-    IRequestHandler<GetAllRolesQuery, BaseResultList<RolesViewModel>>
+    RequestHandlerAsync<GetAllRolesQuery>
 {
-    public async Task<BaseResultList<RolesViewModel>> Handle(
-        GetAllRolesQuery request,
-        CancellationToken cancellationToken)
+    public override async Task<GetAllRolesQuery> HandleAsync(
+        GetAllRolesQuery query,
+        CancellationToken cancellationToken = default)
     {
         var roles = await roleService.GetAllRolesAsync();
 
         var rolesViewModel = roles.Select(role => new RolesViewModel(role.Id, role.Name));
 
-        return new BaseResultList<RolesViewModel>(rolesViewModel, null, true, "Obtido com sucesso");
+        query.Result = new BaseResultList<RolesViewModel>(rolesViewModel, null, true, "Obtido com sucesso");
+
+        return await base.HandleAsync(query, cancellationToken);
     }
 }

--- a/src/EChamado/Server/EChamado.Server.Application/UseCases/Roles/Queries/Handlers/GetRoleByIdQueryHandler.cs
+++ b/src/EChamado/Server/EChamado.Server.Application/UseCases/Roles/Queries/Handlers/GetRoleByIdQueryHandler.cs
@@ -2,24 +2,26 @@
 using EChamado.Server.Domain.Exceptions;
 using EChamado.Server.Domain.Services.Interface;
 using EChamado.Shared.Responses;
-using MediatR;
+using Paramore.Brighter;
 
 namespace EChamado.Server.Application.UseCases.Roles.Queries.Handlers;
 
 public class GetRoleByIdQueryHandler(IRoleService roleService) :
-    IRequestHandler<GetRoleByIdQuery, BaseResult<RolesViewModel>>
+    RequestHandlerAsync<GetRoleByIdQuery>
 {
-    public async Task<BaseResult<RolesViewModel>> Handle(
-        GetRoleByIdQuery request,
-        CancellationToken cancellationToken)
+    public override async Task<GetRoleByIdQuery> HandleAsync(
+        GetRoleByIdQuery query,
+        CancellationToken cancellationToken = default)
     {
-        var role = await roleService.GetRoleByIdAsync(request.Id);
+        var role = await roleService.GetRoleByIdAsync(query.Id);
 
         if (role == null)
             throw new NotFoundException("Role não encontrada");
 
         var rolesViewModel = new RolesViewModel(role.Id, role.Name);
 
-        return new BaseResult<RolesViewModel>(rolesViewModel, true, "Obtido com sucesso");
+        query.Result = new BaseResult<RolesViewModel>(rolesViewModel, true, "Obtido com sucesso");
+
+        return await base.HandleAsync(query, cancellationToken);
     }
 }

--- a/src/EChamado/Server/EChamado.Server.Application/UseCases/Roles/Queries/Handlers/GetRoleByNameQueryHandler.cs
+++ b/src/EChamado/Server/EChamado.Server.Application/UseCases/Roles/Queries/Handlers/GetRoleByNameQueryHandler.cs
@@ -2,24 +2,26 @@
 using EChamado.Server.Domain.Exceptions;
 using EChamado.Server.Domain.Services.Interface;
 using EChamado.Shared.Responses;
-using MediatR;
+using Paramore.Brighter;
 
 namespace EChamado.Server.Application.UseCases.Roles.Queries.Handlers;
 
 public class GetRoleByNameQueryHandler(IRoleService roleService) :
-    IRequestHandler<GetRoleByNameQuery, BaseResult<RolesViewModel>>
+    RequestHandlerAsync<GetRoleByNameQuery>
 {
-    public async Task<BaseResult<RolesViewModel>> Handle(
-        GetRoleByNameQuery request,
-        CancellationToken cancellationToken)
+    public override async Task<GetRoleByNameQuery> HandleAsync(
+        GetRoleByNameQuery query,
+        CancellationToken cancellationToken = default)
     {
-        var role = await roleService.GetRoleByNameAsync(request.Name);
+        var role = await roleService.GetRoleByNameAsync(query.Name);
 
         if (role == null)
             throw new NotFoundException("Role não encontrada");
 
         var rolesViewModel = new RolesViewModel(role.Id, role.Name);
 
-        return new BaseResult<RolesViewModel>(rolesViewModel, true, "Obtido com sucesso");
+        query.Result = new BaseResult<RolesViewModel>(rolesViewModel, true, "Obtido com sucesso");
+
+        return await base.HandleAsync(query, cancellationToken);
     }
 }

--- a/src/EChamado/Server/EChamado.Server.Application/UseCases/StatusTypes/Commands/CreateStatusTypeCommand.cs
+++ b/src/EChamado/Server/EChamado.Server.Application/UseCases/StatusTypes/Commands/CreateStatusTypeCommand.cs
@@ -1,9 +1,20 @@
+using EChamado.Server.Application.Common.Messaging;
 using EChamado.Shared.Responses;
-using MediatR;
 
 namespace EChamado.Server.Application.UseCases.StatusTypes.Commands;
 
-public record CreateStatusTypeCommand(
-    string Name,
-    string Description
-) : IRequest<BaseResult<Guid>>;
+public class CreateStatusTypeCommand : BrighterRequest<BaseResult<Guid>>
+{
+    public string Name { get; set; } = string.Empty;
+    public string Description { get; set; } = string.Empty;
+
+    public CreateStatusTypeCommand()
+    {
+    }
+
+    public CreateStatusTypeCommand(string name, string description)
+    {
+        Name = name;
+        Description = description;
+    }
+}

--- a/src/EChamado/Server/EChamado.Server.Application/UseCases/StatusTypes/Commands/CreateStatusTypeCommandHandler.cs
+++ b/src/EChamado/Server/EChamado.Server.Application/UseCases/StatusTypes/Commands/CreateStatusTypeCommandHandler.cs
@@ -1,23 +1,25 @@
+using EChamado.Server.Application.Common.Behaviours;
+using EChamado.Server.Application.UseCases.StatusTypes.Notifications;
 using EChamado.Server.Domain.Entities;
 using EChamado.Server.Domain.Exceptions;
 using EChamado.Server.Domain.Repositories;
 using EChamado.Shared.Responses;
-using MediatR;
 using Microsoft.Extensions.Logging;
-
-using EChamado.Server.Application.UseCases.StatusTypes.Notifications;
+using Paramore.Brighter;
 
 namespace EChamado.Server.Application.UseCases.StatusTypes.Commands;
 
 public class CreateStatusTypeCommandHandler(
     IUnitOfWork unitOfWork,
-    IMediator mediator,
+    IAmACommandProcessor commandProcessor,
     ILogger<CreateStatusTypeCommandHandler> logger) :
-    IRequestHandler<CreateStatusTypeCommand, BaseResult<Guid>>
+    RequestHandlerAsync<CreateStatusTypeCommand>
 {
-    public async Task<BaseResult<Guid>> Handle(CreateStatusTypeCommand request, CancellationToken cancellationToken)
+    [RequestLogging(0, HandlerTiming.Before)]
+    [RequestValidation(1, HandlerTiming.Before)]
+    public override async Task<CreateStatusTypeCommand> HandleAsync(CreateStatusTypeCommand command, CancellationToken cancellationToken = default)
     {
-        var entity = StatusType.Create(request.Name, request.Description);
+        var entity = StatusType.Create(command.Name, command.Description);
 
         if (!entity.IsValid())
         {
@@ -31,10 +33,11 @@ public class CreateStatusTypeCommandHandler(
 
         await unitOfWork.CommitAsync();
 
-        await mediator.Publish(new CreatedStatusTypeNotification(entity.Id, entity.Name, entity.Description));
+        await commandProcessor.PublishAsync(new CreatedStatusTypeNotification(entity.Id, entity.Name, entity.Description), cancellationToken: cancellationToken);
 
         logger.LogInformation("StatusType {StatusTypeId} created successfully", entity.Id);
 
-        return new BaseResult<Guid>(entity.Id);
+        command.Result = new BaseResult<Guid>(entity.Id);
+        return await base.HandleAsync(command, cancellationToken);
     }
 }

--- a/src/EChamado/Server/EChamado.Server.Application/UseCases/StatusTypes/Commands/DeleteStatusTypeCommand.cs
+++ b/src/EChamado/Server/EChamado.Server.Application/UseCases/StatusTypes/Commands/DeleteStatusTypeCommand.cs
@@ -1,6 +1,18 @@
+using EChamado.Server.Application.Common.Messaging;
 using EChamado.Shared.Responses;
-using MediatR;
 
 namespace EChamado.Server.Application.UseCases.StatusTypes.Commands;
 
-public record DeleteStatusTypeCommand(Guid StatusTypeId) : IRequest<BaseResult>;
+public class DeleteStatusTypeCommand : BrighterRequest<BaseResult>
+{
+    public Guid StatusTypeId { get; set; } = default!;
+
+    public DeleteStatusTypeCommand()
+    {
+    }
+
+    public DeleteStatusTypeCommand(Guid statusTypeId)
+    {
+        StatusTypeId = statusTypeId;
+    }
+}

--- a/src/EChamado/Server/EChamado.Server.Application/UseCases/StatusTypes/Commands/UpdateStatusTypeCommand.cs
+++ b/src/EChamado/Server/EChamado.Server.Application/UseCases/StatusTypes/Commands/UpdateStatusTypeCommand.cs
@@ -1,10 +1,22 @@
+using EChamado.Server.Application.Common.Messaging;
 using EChamado.Shared.Responses;
-using MediatR;
 
 namespace EChamado.Server.Application.UseCases.StatusTypes.Commands;
 
-public record UpdateStatusTypeCommand(
-    Guid Id,
-    string Name,
-    string Description
-) : IRequest<BaseResult>;
+public class UpdateStatusTypeCommand : BrighterRequest<BaseResult>
+{
+    public Guid Id { get; set; } = default!;
+    public string Name { get; set; } = string.Empty;
+    public string Description { get; set; } = string.Empty;
+
+    public UpdateStatusTypeCommand()
+    {
+    }
+
+    public UpdateStatusTypeCommand(Guid id, string name, string description)
+    {
+        Id = id;
+        Name = name;
+        Description = description;
+    }
+}

--- a/src/EChamado/Server/EChamado.Server.Application/UseCases/StatusTypes/Notifications/CreatedStatusTypeNotification.cs
+++ b/src/EChamado/Server/EChamado.Server.Application/UseCases/StatusTypes/Notifications/CreatedStatusTypeNotification.cs
@@ -1,13 +1,18 @@
-using MediatR;
+using Paramore.Brighter;
 using System.Text.Json;
 
 namespace EChamado.Server.Application.UseCases.StatusTypes.Notifications;
 
-public class CreatedStatusTypeNotification : INotification
+public class CreatedStatusTypeNotification : IRequest
 {
     public Guid Id { get; set; }
     public string Name { get; set; } = string.Empty;
     public string Description { get; set; } = string.Empty;
+
+    public CreatedStatusTypeNotification()
+    {
+        Id = Guid.NewGuid();
+    }
 
     public CreatedStatusTypeNotification(Guid id, string name, string description)
     {

--- a/src/EChamado/Server/EChamado.Server.Application/UseCases/StatusTypes/Notifications/DeletedStatusTypeNotification.cs
+++ b/src/EChamado/Server/EChamado.Server.Application/UseCases/StatusTypes/Notifications/DeletedStatusTypeNotification.cs
@@ -1,13 +1,18 @@
-using MediatR;
+using Paramore.Brighter;
 using System.Text.Json;
 
 namespace EChamado.Server.Application.UseCases.StatusTypes.Notifications;
 
-public class DeletedStatusTypeNotification : INotification
+public class DeletedStatusTypeNotification : IRequest
 {
     public Guid Id { get; set; }
     public string Name { get; set; } = string.Empty;
     public string Description { get; set; } = string.Empty;
+
+    public DeletedStatusTypeNotification()
+    {
+        Id = Guid.NewGuid();
+    }
 
     public DeletedStatusTypeNotification(Guid id, string name, string description)
     {

--- a/src/EChamado/Server/EChamado.Server.Application/UseCases/StatusTypes/Notifications/UpdatedStatusTypeNotification.cs
+++ b/src/EChamado/Server/EChamado.Server.Application/UseCases/StatusTypes/Notifications/UpdatedStatusTypeNotification.cs
@@ -1,13 +1,18 @@
-using MediatR;
+using Paramore.Brighter;
 using System.Text.Json;
 
 namespace EChamado.Server.Application.UseCases.StatusTypes.Notifications;
 
-public class UpdatedStatusTypeNotification : INotification
+public class UpdatedStatusTypeNotification : IRequest
 {
     public Guid Id { get; set; }
     public string Name { get; set; } = string.Empty;
     public string Description { get; set; } = string.Empty;
+
+    public UpdatedStatusTypeNotification()
+    {
+        Id = Guid.NewGuid();
+    }
 
     public UpdatedStatusTypeNotification(Guid id, string name, string description)
     {

--- a/src/EChamado/Server/EChamado.Server.Application/UseCases/StatusTypes/Queries/GetStatusTypeByIdQuery.cs
+++ b/src/EChamado/Server/EChamado.Server.Application/UseCases/StatusTypes/Queries/GetStatusTypeByIdQuery.cs
@@ -1,7 +1,19 @@
+using EChamado.Server.Application.Common.Messaging;
 using EChamado.Server.Application.UseCases.StatusTypes.ViewModels;
 using EChamado.Shared.Responses;
-using MediatR;
 
 namespace EChamado.Server.Application.UseCases.StatusTypes.Queries;
 
-public record GetStatusTypeByIdQuery(Guid StatusTypeId) : IRequest<BaseResult<StatusTypeViewModel>>;
+public class GetStatusTypeByIdQuery : BrighterRequest<BaseResult<StatusTypeViewModel>>
+{
+    public Guid StatusTypeId { get; set; }
+
+    public GetStatusTypeByIdQuery()
+    {
+    }
+
+    public GetStatusTypeByIdQuery(Guid statusTypeId)
+    {
+        StatusTypeId = statusTypeId;
+    }
+}

--- a/src/EChamado/Server/EChamado.Server.Application/UseCases/StatusTypes/Queries/SearchStatusTypesQuery.cs
+++ b/src/EChamado/Server/EChamado.Server.Application/UseCases/StatusTypes/Queries/SearchStatusTypesQuery.cs
@@ -1,11 +1,11 @@
+using EChamado.Server.Application.Common.Messaging;
 using EChamado.Server.Application.UseCases.StatusTypes.ViewModels;
 using EChamado.Shared.Responses;
 using EChamado.Shared.ViewModels;
-using MediatR;
 
 namespace EChamado.Server.Application.UseCases.StatusTypes.Queries;
 
-public class SearchStatusTypesQuery : BaseSearch, IRequest<BaseResultList<StatusTypeViewModel>>
+public class SearchStatusTypesQuery : BaseSearch, BrighterRequest<BaseResultList<StatusTypeViewModel>>
 {
     public string Name { get; set; } = string.Empty;
     public string Description { get; set; } = string.Empty;

--- a/src/EChamado/Server/EChamado.Server.Application/UseCases/SubCategories/Queries/GetSubCategoryByIdQuery.cs
+++ b/src/EChamado/Server/EChamado.Server.Application/UseCases/SubCategories/Queries/GetSubCategoryByIdQuery.cs
@@ -1,7 +1,19 @@
+using EChamado.Server.Application.Common.Messaging;
 using EChamado.Server.Application.UseCases.Categories.ViewModels;
 using EChamado.Shared.Responses;
-using MediatR;
 
 namespace EChamado.Server.Application.UseCases.SubCategories.Queries;
 
-public record GetSubCategoryByIdQuery(Guid SubCategoryId) : IRequest<BaseResult<SubCategoryViewModel>>;
+public class GetSubCategoryByIdQuery : BrighterRequest<BaseResult<SubCategoryViewModel>>
+{
+    public Guid SubCategoryId { get; set; }
+
+    public GetSubCategoryByIdQuery()
+    {
+    }
+
+    public GetSubCategoryByIdQuery(Guid subCategoryId)
+    {
+        SubCategoryId = subCategoryId;
+    }
+}

--- a/src/EChamado/Server/EChamado.Server.Application/UseCases/SubCategories/Queries/GetSubCategoryByIdQueryHandler.cs
+++ b/src/EChamado/Server/EChamado.Server.Application/UseCases/SubCategories/Queries/GetSubCategoryByIdQueryHandler.cs
@@ -2,7 +2,7 @@ using EChamado.Server.Application.UseCases.Categories.ViewModels;
 using EChamado.Server.Domain.Exceptions;
 using EChamado.Server.Domain.Repositories;
 using EChamado.Shared.Responses;
-using MediatR;
+using Paramore.Brighter;
 using Microsoft.Extensions.Logging;
 
 namespace EChamado.Server.Application.UseCases.SubCategories.Queries;
@@ -10,16 +10,16 @@ namespace EChamado.Server.Application.UseCases.SubCategories.Queries;
 public class GetSubCategoryByIdQueryHandler(
     IUnitOfWork unitOfWork,
     ILogger<GetSubCategoryByIdQueryHandler> logger) :
-    IRequestHandler<GetSubCategoryByIdQuery, BaseResult<SubCategoryViewModel>>
+    RequestHandlerAsync<GetSubCategoryByIdQuery>
 {
-    public async Task<BaseResult<SubCategoryViewModel>> Handle(GetSubCategoryByIdQuery request, CancellationToken cancellationToken)
+    public override async Task<GetSubCategoryByIdQuery> HandleAsync(GetSubCategoryByIdQuery query, CancellationToken cancellationToken = default)
     {
-        var subCategory = await unitOfWork.SubCategories.GetByIdAsync(request.SubCategoryId, cancellationToken);
+        var subCategory = await unitOfWork.SubCategories.GetByIdAsync(query.SubCategoryId, cancellationToken);
 
         if (subCategory == null)
         {
-            logger.LogError("SubCategory {SubCategoryId} not found", request.SubCategoryId);
-            throw new NotFoundException($"SubCategory {request.SubCategoryId} not found");
+            logger.LogError("SubCategory {SubCategoryId} not found", query.SubCategoryId);
+            throw new NotFoundException($"SubCategory {query.SubCategoryId} not found");
         }
 
         var viewModel = new SubCategoryViewModel(
@@ -29,8 +29,10 @@ public class GetSubCategoryByIdQueryHandler(
             subCategory.CategoryId
         );
 
-        logger.LogInformation("SubCategory {SubCategoryId} retrieved successfully", request.SubCategoryId);
+        logger.LogInformation("SubCategory {SubCategoryId} retrieved successfully", query.SubCategoryId);
 
-        return new BaseResult<SubCategoryViewModel>(viewModel);
+        query.Result = new BaseResult<SubCategoryViewModel>(viewModel);
+
+        return await base.HandleAsync(query, cancellationToken);
     }
 }

--- a/src/EChamado/Server/EChamado.Server.Application/UseCases/SubCategories/Queries/SearchSubCategoriesQuery.cs
+++ b/src/EChamado/Server/EChamado.Server.Application/UseCases/SubCategories/Queries/SearchSubCategoriesQuery.cs
@@ -1,11 +1,11 @@
+using EChamado.Server.Application.Common.Messaging;
 using EChamado.Server.Application.UseCases.Categories.ViewModels;
 using EChamado.Shared.Responses;
 using EChamado.Shared.ViewModels;
-using MediatR;
 
 namespace EChamado.Server.Application.UseCases.SubCategories.Queries;
 
-public class SearchSubCategoriesQuery : BaseSearch, IRequest<BaseResultList<SubCategoryViewModel>>
+public class SearchSubCategoriesQuery : BaseSearch, BrighterRequest<BaseResultList<SubCategoryViewModel>>
 {
     public string Name { get; set; } = string.Empty;
     public string Description { get; set; } = string.Empty;

--- a/src/EChamado/Server/EChamado.Server.Application/UseCases/Users/Queries/GetAllUsersQuery.cs
+++ b/src/EChamado/Server/EChamado.Server.Application/UseCases/Users/Queries/GetAllUsersQuery.cs
@@ -1,9 +1,9 @@
-﻿using EChamado.Server.Application.UseCases.Users.ViewModels;
+﻿using EChamado.Server.Application.Common.Messaging;
+using EChamado.Server.Application.UseCases.Users.ViewModels;
 using EChamado.Shared.Responses;
-using MediatR;
 
 namespace EChamado.Server.Application.UseCases.Users.Queries;
 
-public class GetAllUsersQuery : IRequest<BaseResultList<ApplicationUserViewModel>>
+public class GetAllUsersQuery : BrighterRequest<BaseResultList<ApplicationUserViewModel>>
 {
 }

--- a/src/EChamado/Server/EChamado.Server.Application/UseCases/Users/Queries/GetByEmailUserQuery.cs
+++ b/src/EChamado/Server/EChamado.Server.Application/UseCases/Users/Queries/GetByEmailUserQuery.cs
@@ -1,12 +1,16 @@
-﻿using EChamado.Server.Application.UseCases.Users.ViewModels;
+﻿using EChamado.Server.Application.Common.Messaging;
+using EChamado.Server.Application.UseCases.Users.ViewModels;
 using EChamado.Shared.Responses;
-using MediatR;
 
 namespace EChamado.Server.Application.UseCases.Users.Queries;
 
-public class GetByEmailUserQuery : IRequest<BaseResult<ApplicationUserViewModel>>
+public class GetByEmailUserQuery : BrighterRequest<BaseResult<ApplicationUserViewModel>>
 {
     public string Email { get; set; } = string.Empty;
+
+    public GetByEmailUserQuery()
+    {
+    }
 
     public GetByEmailUserQuery(string email)
     {

--- a/src/EChamado/Server/EChamado.Server.Application/UseCases/Users/Queries/GetByIdUserQuery.cs
+++ b/src/EChamado/Server/EChamado.Server.Application/UseCases/Users/Queries/GetByIdUserQuery.cs
@@ -1,12 +1,16 @@
-﻿using EChamado.Server.Application.UseCases.Users.ViewModels;
+﻿using EChamado.Server.Application.Common.Messaging;
+using EChamado.Server.Application.UseCases.Users.ViewModels;
 using EChamado.Shared.Responses;
-using MediatR;
 
 namespace EChamado.Server.Application.UseCases.Users.Queries;
 
-public class GetByIdUserQuery : IRequest<BaseResult<ApplicationUserViewModel>>
+public class GetByIdUserQuery : BrighterRequest<BaseResult<ApplicationUserViewModel>>
 {
     public Guid Id { get; set; }
+
+    public GetByIdUserQuery()
+    {
+    }
 
     public GetByIdUserQuery(Guid id)
     {

--- a/src/EChamado/Server/EChamado.Server.Application/UseCases/Users/Queries/Handlers/GetAllUsersQueryHandler.cs
+++ b/src/EChamado/Server/EChamado.Server.Application/UseCases/Users/Queries/Handlers/GetAllUsersQueryHandler.cs
@@ -1,23 +1,25 @@
 ﻿using EChamado.Server.Application.UseCases.Users.ViewModels;
 using EChamado.Server.Domain.Services.Interface;
 using EChamado.Shared.Responses;
-using MediatR;
+using Paramore.Brighter;
 
 namespace EChamado.Server.Application.UseCases.Users.Queries.Handlers;
 
 public class GetAllUsersQueryHandler(IApplicationUserService applicationUserService) :
-    IRequestHandler<GetAllUsersQuery, BaseResultList<ApplicationUserViewModel>>
+    RequestHandlerAsync<GetAllUsersQuery>
 {
-    public async Task<BaseResultList<ApplicationUserViewModel>> Handle(
-        GetAllUsersQuery request, 
-        CancellationToken cancellationToken)
+    public override async Task<GetAllUsersQuery> HandleAsync(
+        GetAllUsersQuery query,
+        CancellationToken cancellationToken = default)
     {
         var users = await applicationUserService.GetAllUsersAsync();
 
-        return new BaseResultList<ApplicationUserViewModel>(users
-            .Select(x => new ApplicationUserViewModel(x)), 
-            null, 
-            true, 
+        query.Result = new BaseResultList<ApplicationUserViewModel>(users
+            .Select(x => new ApplicationUserViewModel(x)),
+            null,
+            true,
             "Obtido com sucesso");
+
+        return await base.HandleAsync(query, cancellationToken);
     }
 }

--- a/src/EChamado/Server/EChamado.Server.Application/UseCases/Users/Queries/Handlers/GetByEmailUserQueryHandler.cs
+++ b/src/EChamado/Server/EChamado.Server.Application/UseCases/Users/Queries/Handlers/GetByEmailUserQueryHandler.cs
@@ -1,22 +1,24 @@
 ﻿using EChamado.Server.Application.UseCases.Users.ViewModels;
 using EChamado.Server.Domain.Services.Interface;
 using EChamado.Shared.Responses;
-using MediatR;
+using Paramore.Brighter;
 
 namespace EChamado.Server.Application.UseCases.Users.Queries.Handlers;
 
 public class GetByEmailUserQueryHandler(IApplicationUserService applicationUserService) :
-    IRequestHandler<GetByEmailUserQuery, BaseResult<ApplicationUserViewModel>>
+    RequestHandlerAsync<GetByEmailUserQuery>
 {
-    public async Task<BaseResult<ApplicationUserViewModel>> Handle(
-        GetByEmailUserQuery request, 
-        CancellationToken cancellationToken)
+    public override async Task<GetByEmailUserQuery> HandleAsync(
+        GetByEmailUserQuery query,
+        CancellationToken cancellationToken = default)
     {
-        var users = await applicationUserService.FindByEmailAsync(request.Email);
+        var users = await applicationUserService.FindByEmailAsync(query.Email);
 
-        return new BaseResult<ApplicationUserViewModel>(
+        query.Result = new BaseResult<ApplicationUserViewModel>(
             new ApplicationUserViewModel(users),
             true,
             "Obtido com sucesso");
+
+        return await base.HandleAsync(query, cancellationToken);
     }
 }

--- a/src/EChamado/Server/EChamado.Server.Application/UseCases/Users/Queries/Handlers/GetByIdUserQueryHandler.cs
+++ b/src/EChamado/Server/EChamado.Server.Application/UseCases/Users/Queries/Handlers/GetByIdUserQueryHandler.cs
@@ -1,20 +1,22 @@
 ﻿using EChamado.Server.Application.UseCases.Users.ViewModels;
 using EChamado.Server.Domain.Services.Interface;
 using EChamado.Shared.Responses;
-using MediatR;
+using Paramore.Brighter;
 
 namespace EChamado.Server.Application.UseCases.Users.Queries.Handlers;
 
 public class GetByIdUserQueryHandler(IApplicationUserService applicationUserService) :
-    IRequestHandler<GetByIdUserQuery, BaseResult<ApplicationUserViewModel>>
+    RequestHandlerAsync<GetByIdUserQuery>
 {
-    public async Task<BaseResult<ApplicationUserViewModel>> Handle(GetByIdUserQuery request, CancellationToken cancellationToken)
+    public override async Task<GetByIdUserQuery> HandleAsync(GetByIdUserQuery query, CancellationToken cancellationToken = default)
     {
-        var users = await applicationUserService.FindByIdAsync(request.Id);
-        
-        return new BaseResult<ApplicationUserViewModel>(
-            new ApplicationUserViewModel(users), 
-            true, 
+        var users = await applicationUserService.FindByIdAsync(query.Id);
+
+        query.Result = new BaseResult<ApplicationUserViewModel>(
+            new ApplicationUserViewModel(users),
+            true,
             "Obtido com sucesso");
+
+        return await base.HandleAsync(query, cancellationToken);
     }
 }

--- a/src/EChamado/Server/EChamado.Server/Endpoints/Auth/LoginUserEndpoint.cs
+++ b/src/EChamado/Server/EChamado.Server/Endpoints/Auth/LoginUserEndpoint.cs
@@ -1,8 +1,9 @@
-﻿using EChamado.Server.Application.UseCases.Auth.Commands;
+﻿using EChamado.Server.Application.Common.Messaging;
+using EChamado.Server.Application.UseCases.Auth.Commands;
 using EChamado.Server.Common.Api;
 using EChamado.Shared.Responses;
 using EChamado.Shared.ViewModels.Auth;
-using MediatR;
+using Paramore.Brighter;
 
 namespace EChamado.Server.Endpoints.Auth;
 
@@ -17,11 +18,11 @@ public class LoginUserEndpoint : IEndpoint
             .Produces<BaseResult<LoginResponseViewModel?>>();
 
     private static async Task<IResult> HandleAsync(
-        IMediator mediator,
+        IAmACommandProcessor commandProcessor,
         LoginUserCommand command)
     {
 
-        var result = await mediator.Send(command);
+        var result = await commandProcessor.Send(command);
 
         if (result.Success)
         {

--- a/src/EChamado/Server/EChamado.Server/Endpoints/Auth/RegisterUserEndpoint.cs
+++ b/src/EChamado/Server/EChamado.Server/Endpoints/Auth/RegisterUserEndpoint.cs
@@ -1,8 +1,9 @@
-﻿using EChamado.Server.Application.UseCases.Auth.Commands;
+﻿using EChamado.Server.Application.Common.Messaging;
+using EChamado.Server.Application.UseCases.Auth.Commands;
 using EChamado.Server.Common.Api;
 using EChamado.Shared.Responses;
 using EChamado.Shared.ViewModels.Auth;
-using MediatR;
+using Paramore.Brighter;
 
 namespace EChamado.Server.Endpoints.Auth;
 
@@ -17,11 +18,11 @@ public class RegisterUserEndpoint : IEndpoint
              .Produces<BaseResult<LoginResponseViewModel?>>();
 
     private static async Task<IResult> HandleAsync(
-        IMediator mediator,
+        IAmACommandProcessor commandProcessor,
         RegisterUserCommand command)
     {
 
-        var result = await mediator.Send(command);
+        var result = await commandProcessor.Send(command);
 
         if (result.Success)
         {

--- a/src/EChamado/Server/EChamado.Server/Endpoints/Categories/CreateCategoryEndpoint.cs
+++ b/src/EChamado/Server/EChamado.Server/Endpoints/Categories/CreateCategoryEndpoint.cs
@@ -1,6 +1,7 @@
+using EChamado.Server.Application.Common.Messaging;
 using EChamado.Server.Application.UseCases.Categories.Commands;
 using EChamado.Shared.Responses;
-using MediatR;
+using Paramore.Brighter;
 
 namespace EChamado.Server.Endpoints.Categories;
 
@@ -12,7 +13,7 @@ public class CreateCategoryEndpoint : IEndpoint
             .Produces<BaseResult<Guid>>();
 
     private static async Task<IResult> HandleAsync(
-        IMediator mediator,
+        IAmACommandProcessor commandProcessor,
         CreateCategoryRequest request)
     {
         var command = new CreateCategoryCommand(
@@ -20,7 +21,7 @@ public class CreateCategoryEndpoint : IEndpoint
             request.Description
         );
 
-        var result = await mediator.Send(command);
+        var result = await commandProcessor.Send(command);
 
         if (result.Success)
             return TypedResults.Ok(result);

--- a/src/EChamado/Server/EChamado.Server/Endpoints/Categories/DeleteCategoryEndpoint.cs
+++ b/src/EChamado/Server/EChamado.Server/Endpoints/Categories/DeleteCategoryEndpoint.cs
@@ -1,6 +1,7 @@
+using EChamado.Server.Application.Common.Messaging;
 using EChamado.Server.Application.UseCases.Categories.Commands;
 using EChamado.Shared.Responses;
-using MediatR;
+using Paramore.Brighter;
 
 namespace EChamado.Server.Endpoints.Categories;
 
@@ -12,11 +13,11 @@ public class DeleteCategoryEndpoint : IEndpoint
             .Produces<BaseResult>();
 
     private static async Task<IResult> HandleAsync(
-        IMediator mediator,
+        IAmACommandProcessor commandProcessor,
         Guid id)
     {
         var command = new DeleteCategoryCommand(id);
-        var result = await mediator.Send(command);
+        var result = await commandProcessor.Send(command);
 
         if (result.Success)
             return TypedResults.Ok(result);

--- a/src/EChamado/Server/EChamado.Server/Endpoints/Categories/GetCategoryByIdEndpoint.cs
+++ b/src/EChamado/Server/EChamado.Server/Endpoints/Categories/GetCategoryByIdEndpoint.cs
@@ -1,7 +1,8 @@
+using EChamado.Server.Application.Common.Messaging;
 using EChamado.Server.Application.UseCases.Categories.Queries;
 using EChamado.Server.Application.UseCases.Categories.ViewModels;
 using EChamado.Shared.Responses;
-using MediatR;
+using Paramore.Brighter;
 
 namespace EChamado.Server.Endpoints.Categories;
 
@@ -13,11 +14,11 @@ public class GetCategoryByIdEndpoint : IEndpoint
             .Produces<BaseResult<CategoryViewModel>>();
 
     private static async Task<IResult> HandleAsync(
-        IMediator mediator,
+        IAmACommandProcessor commandProcessor,
         Guid id)
     {
         var query = new GetCategoryByIdQuery(id);
-        var result = await mediator.Send(query);
+        var result = await commandProcessor.Send(query);
 
         if (result.Success)
             return TypedResults.Ok(result);

--- a/src/EChamado/Server/EChamado.Server/Endpoints/Categories/SearchCategoriesEndpoint.cs
+++ b/src/EChamado/Server/EChamado.Server/Endpoints/Categories/SearchCategoriesEndpoint.cs
@@ -1,8 +1,9 @@
+using EChamado.Server.Application.Common.Messaging;
 using EChamado.Server.Application.UseCases.Categories.Queries;
 using EChamado.Server.Application.UseCases.Categories.ViewModels;
 using EChamado.Shared.Responses;
-using MediatR;
 using Microsoft.AspNetCore.Mvc;
+using Paramore.Brighter;
 
 namespace EChamado.Server.Endpoints.Categories;
 
@@ -14,7 +15,7 @@ public class SearchCategoriesEndpoint : IEndpoint
             .Produces<BaseResultList<CategoryViewModel>>();
 
     private static async Task<IResult> HandleAsync(
-        IMediator mediator,
+        IAmACommandProcessor commandProcessor,
         [AsParameters] SearchCategoriesParameters parameters)
     {
         var query = new SearchCategoriesQuery
@@ -30,7 +31,7 @@ public class SearchCategoriesEndpoint : IEndpoint
             PageSize = parameters.PageSize
         };
 
-        var result = await mediator.Send(query);
+        var result = await commandProcessor.Send(query);
 
         if (result.Success)
             return TypedResults.Ok(result);

--- a/src/EChamado/Server/EChamado.Server/Endpoints/Categories/UpdateCategoryEndpoint.cs
+++ b/src/EChamado/Server/EChamado.Server/Endpoints/Categories/UpdateCategoryEndpoint.cs
@@ -1,6 +1,7 @@
+using EChamado.Server.Application.Common.Messaging;
 using EChamado.Server.Application.UseCases.Categories.Commands;
 using EChamado.Shared.Responses;
-using MediatR;
+using Paramore.Brighter;
 
 namespace EChamado.Server.Endpoints.Categories;
 
@@ -12,7 +13,7 @@ public class UpdateCategoryEndpoint : IEndpoint
             .Produces<BaseResult>();
 
     private static async Task<IResult> HandleAsync(
-        IMediator mediator,
+        IAmACommandProcessor commandProcessor,
         Guid id,
         UpdateCategoryRequest request)
     {
@@ -22,7 +23,7 @@ public class UpdateCategoryEndpoint : IEndpoint
             request.Description
         );
 
-        var result = await mediator.Send(command);
+        var result = await commandProcessor.Send(command);
 
         if (result.Success)
             return TypedResults.Ok(result);

--- a/src/EChamado/Server/EChamado.Server/Endpoints/Comments/CreateCommentEndpoint.cs
+++ b/src/EChamado/Server/EChamado.Server/Endpoints/Comments/CreateCommentEndpoint.cs
@@ -1,6 +1,7 @@
+using EChamado.Server.Application.Common.Messaging;
 using EChamado.Server.Application.UseCases.Comments.Commands;
 using EChamado.Shared.Responses;
-using MediatR;
+using Paramore.Brighter;
 
 namespace EChamado.Server.Endpoints.Comments;
 
@@ -12,7 +13,7 @@ public class CreateCommentEndpoint : IEndpoint
             .Produces<BaseResult<Guid>>();
 
     private static async Task<IResult> HandleAsync(
-        IMediator mediator,
+        IAmACommandProcessor commandProcessor,
         Guid orderId,
         CreateCommentRequest request)
     {
@@ -23,7 +24,7 @@ public class CreateCommentEndpoint : IEndpoint
             request.UserEmail
         );
 
-        var result = await mediator.Send(command);
+        var result = await commandProcessor.Send(command);
 
         if (result.Success)
             return TypedResults.Ok(result);

--- a/src/EChamado/Server/EChamado.Server/Endpoints/Comments/DeleteCommentEndpoint.cs
+++ b/src/EChamado/Server/EChamado.Server/Endpoints/Comments/DeleteCommentEndpoint.cs
@@ -1,6 +1,7 @@
+using EChamado.Server.Application.Common.Messaging;
 using EChamado.Server.Application.UseCases.Comments.Commands;
 using EChamado.Shared.Responses;
-using MediatR;
+using Paramore.Brighter;
 
 namespace EChamado.Server.Endpoints.Comments;
 
@@ -12,11 +13,11 @@ public class DeleteCommentEndpoint : IEndpoint
             .Produces<BaseResult>();
 
     private static async Task<IResult> HandleAsync(
-        IMediator mediator,
+        IAmACommandProcessor commandProcessor,
         Guid id)
     {
         var command = new DeleteCommentCommand(id);
-        var result = await mediator.Send(command);
+        var result = await commandProcessor.Send(command);
 
         if (result.Success)
             return TypedResults.Ok(result);

--- a/src/EChamado/Server/EChamado.Server/Endpoints/Comments/GetCommentsByOrderIdEndpoint.cs
+++ b/src/EChamado/Server/EChamado.Server/Endpoints/Comments/GetCommentsByOrderIdEndpoint.cs
@@ -1,7 +1,8 @@
+using EChamado.Server.Application.Common.Messaging;
 using EChamado.Server.Application.UseCases.Comments.Queries;
 using EChamado.Server.Application.UseCases.Comments.ViewModels;
 using EChamado.Shared.Responses;
-using MediatR;
+using Paramore.Brighter;
 
 namespace EChamado.Server.Endpoints.Comments;
 
@@ -13,11 +14,11 @@ public class GetCommentsByOrderIdEndpoint : IEndpoint
             .Produces<BaseResultList<CommentViewModel>>();
 
     private static async Task<IResult> HandleAsync(
-        IMediator mediator,
+        IAmACommandProcessor commandProcessor,
         Guid orderId)
     {
         var query = new GetCommentsByOrderIdQuery(orderId);
-        var result = await mediator.Send(query);
+        var result = await commandProcessor.Send(query);
 
         if (result.Success)
             return TypedResults.Ok(result);

--- a/src/EChamado/Server/EChamado.Server/Endpoints/Departments/CreateDepartmentEndpoint.cs
+++ b/src/EChamado/Server/EChamado.Server/Endpoints/Departments/CreateDepartmentEndpoint.cs
@@ -1,7 +1,8 @@
-﻿using EChamado.Server.Application.UseCases.Departments.Commands;
+﻿using EChamado.Server.Application.Common.Messaging;
+using EChamado.Server.Application.UseCases.Departments.Commands;
 using EChamado.Server.Common.Api;
 using EChamado.Shared.Responses;
-using MediatR;
+using Paramore.Brighter;
 
 namespace EChamado.Server.Endpoints.Departments;
 
@@ -16,11 +17,11 @@ public class CreateDepartmentEndpoint : IEndpoint
         .Produces<BaseResult<Guid>>();
 
     private static async Task<IResult> HandleAsync(
-        IMediator mediator,
+        IAmACommandProcessor commandProcessor,
         CreateDepartmentCommand command)
     {
 
-        var result = await mediator.Send(command);
+        var result = await commandProcessor.Send(command);
 
         if (result.Success)
         {

--- a/src/EChamado/Server/EChamado.Server/Endpoints/Departments/DeletesDepartmentEndpoint.cs
+++ b/src/EChamado/Server/EChamado.Server/Endpoints/Departments/DeletesDepartmentEndpoint.cs
@@ -1,8 +1,9 @@
-﻿using EChamado.Server.Application.UseCases.Departments.Commands;
+﻿using EChamado.Server.Application.Common.Messaging;
+using EChamado.Server.Application.UseCases.Departments.Commands;
 using EChamado.Server.Common.Api;
 using EChamado.Shared.Responses;
-using MediatR;
 using Microsoft.AspNetCore.Mvc;
+using Paramore.Brighter;
 
 namespace EChamado.Server.Endpoints.Departments;
 
@@ -17,7 +18,7 @@ public class DeletesDepartmentEndpoint : IEndpoint
         .Produces<BaseResult>();
 
     private static async Task<IResult> HandleAsync(
-        IMediator mediator,
+        IAmACommandProcessor commandProcessor,
         [FromQuery(Name = "ids")] Guid[] ids)
     {
         if (ids == null || !ids.Any())
@@ -25,7 +26,7 @@ public class DeletesDepartmentEndpoint : IEndpoint
             return TypedResults.BadRequest(new BaseResult(false, "Nenhum ID foi fornecido."));
         }
 
-        var result = await mediator.Send(new DeletesDepartmentCommand(ids));
+        var result = await commandProcessor.Send(new DeletesDepartmentCommand(ids));
 
         if (result.Success)
         {

--- a/src/EChamado/Server/EChamado.Server/Endpoints/Departments/DisableDepartmentEndpoint.cs
+++ b/src/EChamado/Server/EChamado.Server/Endpoints/Departments/DisableDepartmentEndpoint.cs
@@ -1,8 +1,9 @@
-﻿using EChamado.Server.Application.UseCases.Departments.Commands;
+﻿using EChamado.Server.Application.Common.Messaging;
+using EChamado.Server.Application.UseCases.Departments.Commands;
 using EChamado.Server.Common.Api;
 using EChamado.Shared.Responses;
-using MediatR;
 using Microsoft.AspNetCore.Mvc;
+using Paramore.Brighter;
 
 namespace EChamado.Server.Endpoints.Departments;
 
@@ -17,10 +18,10 @@ public class DisableDepartmentEndpoint : IEndpoint
         .Produces<BaseResult>();
 
     private static async Task<IResult> HandleAsync(
-        IMediator mediator,
+        IAmACommandProcessor commandProcessor,
         [FromRoute] Guid id)
     {
-        var result = await mediator.Send(new DisableDepartmentCommand(id));
+        var result = await commandProcessor.Send(new DisableDepartmentCommand(id));
 
         if (result.Success)
         {

--- a/src/EChamado/Server/EChamado.Server/Endpoints/Departments/GetByIdDepartmentEndpoint.cs
+++ b/src/EChamado/Server/EChamado.Server/Endpoints/Departments/GetByIdDepartmentEndpoint.cs
@@ -1,8 +1,9 @@
-﻿using EChamado.Server.Application.UseCases.Departments.Queries;
+﻿using EChamado.Server.Application.Common.Messaging;
+using EChamado.Server.Application.UseCases.Departments.Queries;
 using EChamado.Server.Application.UseCases.Departments.ViewModels;
 using EChamado.Server.Common.Api;
 using EChamado.Shared.Responses;
-using MediatR;
+using Paramore.Brighter;
 
 namespace EChamado.Server.Endpoints.Departments;
 
@@ -17,10 +18,10 @@ public class GetByIdDepartmentEndpoint : IEndpoint
         .Produces<BaseResult<DepartmentViewModel>>();
 
     private static async Task<IResult> HandleAsync(
-        IMediator mediator, 
+        IAmACommandProcessor commandProcessor,
         Guid id)
     {
-        var result = await mediator.Send(new GetByIdDepartmentQuery(id));
+        var result = await commandProcessor.Send(new GetByIdDepartmentQuery(id));
 
         if (result.Success)
         {

--- a/src/EChamado/Server/EChamado.Server/Endpoints/Departments/SearchDepartmentEndpoint.cs
+++ b/src/EChamado/Server/EChamado.Server/Endpoints/Departments/SearchDepartmentEndpoint.cs
@@ -1,9 +1,10 @@
-﻿using EChamado.Server.Application.UseCases.Departments.Queries;
+﻿using EChamado.Server.Application.Common.Messaging;
+using EChamado.Server.Application.UseCases.Departments.Queries;
 using EChamado.Server.Application.UseCases.Departments.ViewModels;
 using EChamado.Server.Common.Api;
 using EChamado.Shared.Responses;
-using MediatR;
 using Microsoft.AspNetCore.Mvc;
+using Paramore.Brighter;
 
 namespace EChamado.Server.Endpoints.Departments;
 
@@ -18,7 +19,7 @@ public class SearchDepartmentEndpoint : IEndpoint
            .Produces<BaseResultList<DepartmentViewModel>>();
 
     private static async Task<IResult> HandleAsync(
-        IMediator mediator,
+        IAmACommandProcessor commandProcessor,
         [AsParameters] SearchDepartment search)
     {
         var query = new SearchDepartmentQuery
@@ -34,7 +35,7 @@ public class SearchDepartmentEndpoint : IEndpoint
             PageSize = search.PageSize ?? 10,
         };
 
-        var result = await mediator.Send(query);
+        var result = await commandProcessor.Send(query);
 
         if (result.Success)
         {

--- a/src/EChamado/Server/EChamado.Server/Endpoints/Departments/UpdateDepartmentEndpoint.cs
+++ b/src/EChamado/Server/EChamado.Server/Endpoints/Departments/UpdateDepartmentEndpoint.cs
@@ -1,8 +1,9 @@
-﻿using EChamado.Server.Application.UseCases.Departments.Commands;
+﻿using EChamado.Server.Application.Common.Messaging;
+using EChamado.Server.Application.UseCases.Departments.Commands;
 using EChamado.Server.Common.Api;
 using EChamado.Shared.Responses;
-using MediatR;
 using Microsoft.AspNetCore.Mvc;
+using Paramore.Brighter;
 
 namespace EChamado.Server.Endpoints.Departments;
 
@@ -17,7 +18,7 @@ public class UpdateDepartmentEndpoint : IEndpoint
         .Produces<BaseResult>();
 
     private static async Task<IResult> HandleAsync(
-        IMediator mediator,
+        IAmACommandProcessor commandProcessor,
         [FromRoute] Guid id,
         [FromBody] UpdateDepartmentCommand command)
     {
@@ -27,7 +28,7 @@ public class UpdateDepartmentEndpoint : IEndpoint
             return TypedResults.BadRequest("Id da rota e Id do corpo da requisição não são iguais");
         }
 
-        var result = await mediator.Send(command);
+        var result = await commandProcessor.Send(command);
 
         if (result.Success)
         {

--- a/src/EChamado/Server/EChamado.Server/Endpoints/Departments/UpdateStatusDepartmentEndpoint.cs
+++ b/src/EChamado/Server/EChamado.Server/Endpoints/Departments/UpdateStatusDepartmentEndpoint.cs
@@ -1,8 +1,9 @@
-﻿using EChamado.Server.Application.UseCases.Departments.Commands;
+﻿using EChamado.Server.Application.Common.Messaging;
+using EChamado.Server.Application.UseCases.Departments.Commands;
 using EChamado.Server.Common.Api;
 using EChamado.Shared.Responses;
-using MediatR;
 using Microsoft.AspNetCore.Mvc;
+using Paramore.Brighter;
 
 namespace EChamado.Server.Endpoints.Departments;
 
@@ -17,10 +18,10 @@ public class UpdateStatusDepartmentEndpoint : IEndpoint
         .Produces<BaseResult>();
 
     private static async Task<IResult> HandleAsync(
-        IMediator mediator,
+        IAmACommandProcessor commandProcessor,
         [FromBody] UpdateStatusDepartmentCommand command)
     {
-        var result = await mediator.Send(command);
+        var result = await commandProcessor.Send(command);
 
         if (result.Success)
         {

--- a/src/EChamado/Server/EChamado.Server/Endpoints/OrderTypes/CreateOrderTypeEndpoint.cs
+++ b/src/EChamado/Server/EChamado.Server/Endpoints/OrderTypes/CreateOrderTypeEndpoint.cs
@@ -1,6 +1,7 @@
+using EChamado.Server.Application.Common.Messaging;
 using EChamado.Server.Application.UseCases.OrderTypes.Commands;
 using EChamado.Shared.Responses;
-using MediatR;
+using Paramore.Brighter;
 
 namespace EChamado.Server.Endpoints.OrderTypes;
 
@@ -12,7 +13,7 @@ public class CreateOrderTypeEndpoint : IEndpoint
             .Produces<BaseResult<Guid>>();
 
     private static async Task<IResult> HandleAsync(
-        IMediator mediator,
+        IAmACommandProcessor commandProcessor,
         CreateOrderTypeRequest request)
     {
         var command = new CreateOrderTypeCommand(
@@ -20,7 +21,7 @@ public class CreateOrderTypeEndpoint : IEndpoint
             request.Description
         );
 
-        var result = await mediator.Send(command);
+        var result = await commandProcessor.Send(command);
 
         if (result.Success)
             return TypedResults.Ok(result);

--- a/src/EChamado/Server/EChamado.Server/Endpoints/OrderTypes/DeleteOrderTypeEndpoint.cs
+++ b/src/EChamado/Server/EChamado.Server/Endpoints/OrderTypes/DeleteOrderTypeEndpoint.cs
@@ -1,6 +1,7 @@
+using EChamado.Server.Application.Common.Messaging;
 using EChamado.Server.Application.UseCases.OrderTypes.Commands;
 using EChamado.Shared.Responses;
-using MediatR;
+using Paramore.Brighter;
 
 namespace EChamado.Server.Endpoints.OrderTypes;
 
@@ -12,11 +13,11 @@ public class DeleteOrderTypeEndpoint : IEndpoint
             .Produces<BaseResult>();
 
     private static async Task<IResult> HandleAsync(
-        IMediator mediator,
+        IAmACommandProcessor commandProcessor,
         Guid id)
     {
         var command = new DeleteOrderTypeCommand(id);
-        var result = await mediator.Send(command);
+        var result = await commandProcessor.Send(command);
 
         if (result.Success)
             return TypedResults.Ok(result);

--- a/src/EChamado/Server/EChamado.Server/Endpoints/OrderTypes/GetOrderTypeByIdEndpoint.cs
+++ b/src/EChamado/Server/EChamado.Server/Endpoints/OrderTypes/GetOrderTypeByIdEndpoint.cs
@@ -1,7 +1,8 @@
+using EChamado.Server.Application.Common.Messaging;
 using EChamado.Server.Application.UseCases.OrderTypes.Queries;
 using EChamado.Server.Application.UseCases.OrderTypes.ViewModels;
 using EChamado.Shared.Responses;
-using MediatR;
+using Paramore.Brighter;
 
 namespace EChamado.Server.Endpoints.OrderTypes;
 
@@ -13,11 +14,11 @@ public class GetOrderTypeByIdEndpoint : IEndpoint
             .Produces<BaseResult<OrderTypeViewModel>>();
 
     private static async Task<IResult> HandleAsync(
-        IMediator mediator,
+        IAmACommandProcessor commandProcessor,
         Guid id)
     {
         var query = new GetOrderTypeByIdQuery(id);
-        var result = await mediator.Send(query);
+        var result = await commandProcessor.Send(query);
 
         if (result.Success)
             return TypedResults.Ok(result);

--- a/src/EChamado/Server/EChamado.Server/Endpoints/OrderTypes/SearchOrderTypesEndpoint.cs
+++ b/src/EChamado/Server/EChamado.Server/Endpoints/OrderTypes/SearchOrderTypesEndpoint.cs
@@ -1,8 +1,9 @@
+using EChamado.Server.Application.Common.Messaging;
 using EChamado.Server.Application.UseCases.OrderTypes.Queries;
 using EChamado.Server.Application.UseCases.OrderTypes.ViewModels;
 using EChamado.Shared.Responses;
-using MediatR;
 using Microsoft.AspNetCore.Mvc;
+using Paramore.Brighter;
 
 namespace EChamado.Server.Endpoints.OrderTypes;
 
@@ -14,7 +15,7 @@ public class SearchOrderTypesEndpoint : IEndpoint
             .Produces<BaseResultList<OrderTypeViewModel>>();
 
     private static async Task<IResult> HandleAsync(
-        IMediator mediator,
+        IAmACommandProcessor commandProcessor,
         [AsParameters] SearchOrderTypesParameters parameters)
     {
         var query = new SearchOrderTypesQuery
@@ -30,7 +31,7 @@ public class SearchOrderTypesEndpoint : IEndpoint
             PageSize = parameters.PageSize
         };
 
-        var result = await mediator.Send(query);
+        var result = await commandProcessor.Send(query);
 
         if (result.Success)
             return TypedResults.Ok(result);

--- a/src/EChamado/Server/EChamado.Server/Endpoints/OrderTypes/UpdateOrderTypeEndpoint.cs
+++ b/src/EChamado/Server/EChamado.Server/Endpoints/OrderTypes/UpdateOrderTypeEndpoint.cs
@@ -1,6 +1,7 @@
+using EChamado.Server.Application.Common.Messaging;
 using EChamado.Server.Application.UseCases.OrderTypes.Commands;
 using EChamado.Shared.Responses;
-using MediatR;
+using Paramore.Brighter;
 
 namespace EChamado.Server.Endpoints.OrderTypes;
 
@@ -12,7 +13,7 @@ public class UpdateOrderTypeEndpoint : IEndpoint
             .Produces<BaseResult>();
 
     private static async Task<IResult> HandleAsync(
-        IMediator mediator,
+        IAmACommandProcessor commandProcessor,
         Guid id,
         UpdateOrderTypeRequest request)
     {
@@ -22,7 +23,7 @@ public class UpdateOrderTypeEndpoint : IEndpoint
             request.Description
         );
 
-        var result = await mediator.Send(command);
+        var result = await commandProcessor.Send(command);
 
         if (result.Success)
             return TypedResults.Ok(result);

--- a/src/EChamado/Server/EChamado.Server/Endpoints/Orders/AssignOrderEndpoint.cs
+++ b/src/EChamado/Server/EChamado.Server/Endpoints/Orders/AssignOrderEndpoint.cs
@@ -1,7 +1,8 @@
+using EChamado.Server.Application.Common.Messaging;
 using EChamado.Server.Application.UseCases.Orders.Commands;
 using EChamado.Server.Common.Api;
 using EChamado.Shared.Responses;
-using MediatR;
+using Paramore.Brighter;
 
 namespace EChamado.Server.Endpoints.Orders;
 
@@ -16,13 +17,13 @@ public class AssignOrderEndpoint : IEndpoint
         .Produces<BaseResult>();
 
     private static async Task<IResult> HandleAsync(
-        IMediator mediator,
+        IAmACommandProcessor commandProcessor,
         Guid id,
         AssignOrderRequest request)
     {
         var command = new AssignOrderCommand(id, request.AssignedToUserId);
 
-        var result = await mediator.Send(command);
+        var result = await commandProcessor.Send(command);
 
         if (result.Success)
         {

--- a/src/EChamado/Server/EChamado.Server/Endpoints/Orders/ChangeStatusOrderEndpoint.cs
+++ b/src/EChamado/Server/EChamado.Server/Endpoints/Orders/ChangeStatusOrderEndpoint.cs
@@ -1,7 +1,8 @@
+using EChamado.Server.Application.Common.Messaging;
 using EChamado.Server.Application.UseCases.Orders.Commands;
 using EChamado.Server.Common.Api;
 using EChamado.Shared.Responses;
-using MediatR;
+using Paramore.Brighter;
 
 namespace EChamado.Server.Endpoints.Orders;
 
@@ -16,13 +17,13 @@ public class ChangeStatusOrderEndpoint : IEndpoint
         .Produces<BaseResult>();
 
     private static async Task<IResult> HandleAsync(
-        IMediator mediator,
+        IAmACommandProcessor commandProcessor,
         Guid id,
         ChangeStatusRequest request)
     {
         var command = new ChangeStatusOrderCommand(id, request.StatusId);
 
-        var result = await mediator.Send(command);
+        var result = await commandProcessor.Send(command);
 
         if (result.Success)
         {

--- a/src/EChamado/Server/EChamado.Server/Endpoints/Orders/CloseOrderEndpoint.cs
+++ b/src/EChamado/Server/EChamado.Server/Endpoints/Orders/CloseOrderEndpoint.cs
@@ -1,7 +1,8 @@
+using EChamado.Server.Application.Common.Messaging;
 using EChamado.Server.Application.UseCases.Orders.Commands;
 using EChamado.Server.Common.Api;
 using EChamado.Shared.Responses;
-using MediatR;
+using Paramore.Brighter;
 
 namespace EChamado.Server.Endpoints.Orders;
 
@@ -16,13 +17,13 @@ public class CloseOrderEndpoint : IEndpoint
         .Produces<BaseResult>();
 
     private static async Task<IResult> HandleAsync(
-        IMediator mediator,
+        IAmACommandProcessor commandProcessor,
         Guid id,
         CloseOrderRequest request)
     {
         var command = new CloseOrderCommand(id, request.Evaluation);
 
-        var result = await mediator.Send(command);
+        var result = await commandProcessor.Send(command);
 
         if (result.Success)
         {

--- a/src/EChamado/Server/EChamado.Server/Endpoints/Orders/CreateOrderEndpoint.cs
+++ b/src/EChamado/Server/EChamado.Server/Endpoints/Orders/CreateOrderEndpoint.cs
@@ -1,7 +1,8 @@
+using EChamado.Server.Application.Common.Messaging;
 using EChamado.Server.Application.UseCases.Orders.Commands;
 using EChamado.Server.Common.Api;
 using EChamado.Shared.Responses;
-using MediatR;
+using Paramore.Brighter;
 using System.Security.Claims;
 
 namespace EChamado.Server.Endpoints.Orders;
@@ -17,7 +18,7 @@ public class CreateOrderEndpoint : IEndpoint
         .Produces<BaseResult<Guid>>();
 
     private static async Task<IResult> HandleAsync(
-        IMediator mediator,
+        IAmACommandProcessor commandProcessor,
         HttpContext httpContext,
         CreateOrderRequest request)
     {
@@ -41,7 +42,7 @@ public class CreateOrderEndpoint : IEndpoint
             userEmail
         );
 
-        var result = await mediator.Send(command);
+        var result = await commandProcessor.Send(command);
 
         if (result.Success)
         {

--- a/src/EChamado/Server/EChamado.Server/Endpoints/Orders/GetOrderByIdEndpoint.cs
+++ b/src/EChamado/Server/EChamado.Server/Endpoints/Orders/GetOrderByIdEndpoint.cs
@@ -1,8 +1,9 @@
+using EChamado.Server.Application.Common.Messaging;
 using EChamado.Server.Application.UseCases.Orders.Queries;
 using EChamado.Server.Application.UseCases.Orders.ViewModels;
 using EChamado.Server.Common.Api;
 using EChamado.Shared.Responses;
-using MediatR;
+using Paramore.Brighter;
 
 namespace EChamado.Server.Endpoints.Orders;
 
@@ -17,10 +18,10 @@ public class GetOrderByIdEndpoint : IEndpoint
         .Produces<BaseResult<OrderViewModel>>();
 
     private static async Task<IResult> HandleAsync(
-        IMediator mediator,
+        IAmACommandProcessor commandProcessor,
         Guid id)
     {
-        var result = await mediator.Send(new GetOrderByIdQuery(id));
+        var result = await commandProcessor.Send(new GetOrderByIdQuery(id));
 
         if (result.Success)
         {

--- a/src/EChamado/Server/EChamado.Server/Endpoints/Orders/SearchOrdersEndpoint.cs
+++ b/src/EChamado/Server/EChamado.Server/Endpoints/Orders/SearchOrdersEndpoint.cs
@@ -1,9 +1,10 @@
+using EChamado.Server.Application.Common.Messaging;
 using EChamado.Server.Application.UseCases.Orders.Queries;
 using EChamado.Server.Application.UseCases.Orders.ViewModels;
 using EChamado.Server.Common.Api;
 using EChamado.Shared.Responses;
-using MediatR;
 using Microsoft.AspNetCore.Mvc;
+using Paramore.Brighter;
 
 namespace EChamado.Server.Endpoints.Orders;
 
@@ -18,7 +19,7 @@ public class SearchOrdersEndpoint : IEndpoint
            .Produces<BaseResultList<OrderListViewModel>>();
 
     private static async Task<IResult> HandleAsync(
-        IMediator mediator,
+        IAmACommandProcessor commandProcessor,
         [AsParameters] SearchOrdersParameters parameters)
     {
         var query = new SearchOrdersQuery
@@ -37,7 +38,7 @@ public class SearchOrdersEndpoint : IEndpoint
             PageSize = parameters.PageSize ?? 10
         };
 
-        var result = await mediator.Send(query);
+        var result = await commandProcessor.Send(query);
 
         if (result.Success)
         {

--- a/src/EChamado/Server/EChamado.Server/Endpoints/Orders/UpdateOrderEndpoint.cs
+++ b/src/EChamado/Server/EChamado.Server/Endpoints/Orders/UpdateOrderEndpoint.cs
@@ -1,7 +1,8 @@
+using EChamado.Server.Application.Common.Messaging;
 using EChamado.Server.Application.UseCases.Orders.Commands;
 using EChamado.Server.Common.Api;
 using EChamado.Shared.Responses;
-using MediatR;
+using Paramore.Brighter;
 
 namespace EChamado.Server.Endpoints.Orders;
 
@@ -16,7 +17,7 @@ public class UpdateOrderEndpoint : IEndpoint
         .Produces<BaseResult>();
 
     private static async Task<IResult> HandleAsync(
-        IMediator mediator,
+        IAmACommandProcessor commandProcessor,
         Guid id,
         UpdateOrderRequest request)
     {
@@ -31,7 +32,7 @@ public class UpdateOrderEndpoint : IEndpoint
             request.DueDate
         );
 
-        var result = await mediator.Send(command);
+        var result = await commandProcessor.Send(command);
 
         if (result.Success)
         {

--- a/src/EChamado/Server/EChamado.Server/Endpoints/Roles/CreateRoleEndpoint.cs
+++ b/src/EChamado/Server/EChamado.Server/Endpoints/Roles/CreateRoleEndpoint.cs
@@ -1,7 +1,8 @@
-﻿using EChamado.Server.Application.UseCases.Roles.Commands;
+﻿using EChamado.Server.Application.Common.Messaging;
+using EChamado.Server.Application.UseCases.Roles.Commands;
 using EChamado.Server.Common.Api;
 using EChamado.Shared.Responses;
-using MediatR;
+using Paramore.Brighter;
 
 namespace EChamado.Server.Endpoints.Roles;
 
@@ -16,11 +17,11 @@ public class CreateRoleEndpoint : IEndpoint
         .Produces<BaseResult<Guid>>();
 
     private static async Task<IResult> HandleAsync(
-        IMediator mediator,
+        IAmACommandProcessor commandProcessor,
         CreateRoleCommand command)
     {
 
-        var result = await mediator.Send(command);
+        var result = await commandProcessor.Send(command);
 
         if (result.Success)
         {

--- a/src/EChamado/Server/EChamado.Server/Endpoints/Roles/DeleteRoleEndpoint.cs
+++ b/src/EChamado/Server/EChamado.Server/Endpoints/Roles/DeleteRoleEndpoint.cs
@@ -1,8 +1,9 @@
-﻿using EChamado.Server.Application.UseCases.Roles.Commands;
+﻿using EChamado.Server.Application.Common.Messaging;
+using EChamado.Server.Application.UseCases.Roles.Commands;
 using EChamado.Server.Common.Api;
 using EChamado.Shared.Responses;
-using MediatR;
 using Microsoft.AspNetCore.Mvc;
+using Paramore.Brighter;
 
 namespace EChamado.Server.Endpoints.Roles;
 
@@ -17,10 +18,10 @@ public class DeleteRoleEndpoint : IEndpoint
         .Produces<BaseResult>();
 
     private static async Task<IResult> HandleAsync(
-        IMediator mediator,
+        IAmACommandProcessor commandProcessor,
         [FromRoute] Guid id)
     {
-        var result = await mediator.Send(new DeleteRoleCommand(id));
+        var result = await commandProcessor.Send(new DeleteRoleCommand(id));
 
         if (result.Success)
         {

--- a/src/EChamado/Server/EChamado.Server/Endpoints/Roles/GetAllRolesEndpoint.cs
+++ b/src/EChamado/Server/EChamado.Server/Endpoints/Roles/GetAllRolesEndpoint.cs
@@ -1,8 +1,9 @@
-﻿using EChamado.Server.Application.UseCases.Roles.Queries;
+﻿using EChamado.Server.Application.Common.Messaging;
+using EChamado.Server.Application.UseCases.Roles.Queries;
 using EChamado.Server.Application.UseCases.Roles.ViewModels;
 using EChamado.Server.Common.Api;
 using EChamado.Shared.Responses;
-using MediatR;
+using Paramore.Brighter;
 
 namespace EChamado.Server.Endpoints.Roles;
 
@@ -17,9 +18,9 @@ public class GetAllRolesEndpoint : IEndpoint
         .Produces<BaseResultList<RolesViewModel>>();
 
     private static async Task<IResult> HandleAsync(
-        IMediator mediator)
+        IAmACommandProcessor commandProcessor)
     {
-        var result = await mediator.Send(new GetAllRolesQuery());
+        var result = await commandProcessor.Send(new GetAllRolesQuery());
 
         if (result.Success)
         {

--- a/src/EChamado/Server/EChamado.Server/Endpoints/Roles/GetRoleByIdEndpoint.cs
+++ b/src/EChamado/Server/EChamado.Server/Endpoints/Roles/GetRoleByIdEndpoint.cs
@@ -1,9 +1,10 @@
-﻿using EChamado.Server.Application.UseCases.Roles.Queries;
+﻿using EChamado.Server.Application.Common.Messaging;
+using EChamado.Server.Application.UseCases.Roles.Queries;
 using EChamado.Server.Application.UseCases.Roles.ViewModels;
 using EChamado.Server.Common.Api;
 using EChamado.Shared.Responses;
-using MediatR;
 using Microsoft.AspNetCore.Mvc;
+using Paramore.Brighter;
 
 namespace EChamado.Server.Endpoints.Roles;
 
@@ -18,10 +19,10 @@ public class GetRoleByIdEndpoint : IEndpoint
         .Produces<BaseResult<RolesViewModel>>();
 
     private static async Task<IResult> HandleAsync(
-        IMediator mediator,
+        IAmACommandProcessor commandProcessor,
         [FromRoute]  Guid id)
     {
-        var result = await mediator.Send(new GetRoleByIdQuery(id));
+        var result = await commandProcessor.Send(new GetRoleByIdQuery(id));
 
         if (result.Success)
         {

--- a/src/EChamado/Server/EChamado.Server/Endpoints/Roles/GetRoleByNameEndpoint.cs
+++ b/src/EChamado/Server/EChamado.Server/Endpoints/Roles/GetRoleByNameEndpoint.cs
@@ -1,9 +1,10 @@
-﻿using EChamado.Server.Application.UseCases.Roles.Queries;
+﻿using EChamado.Server.Application.Common.Messaging;
+using EChamado.Server.Application.UseCases.Roles.Queries;
 using EChamado.Server.Application.UseCases.Roles.ViewModels;
 using EChamado.Server.Common.Api;
 using EChamado.Shared.Responses;
-using MediatR;
 using Microsoft.AspNetCore.Mvc;
+using Paramore.Brighter;
 
 namespace EChamado.Server.Endpoints.Roles;
 
@@ -18,10 +19,10 @@ public class GetRoleByNameEndpoint : IEndpoint
         .Produces<BaseResult<RolesViewModel>>();
 
     private static async Task<IResult> HandleAsync(
-        IMediator mediator,
+        IAmACommandProcessor commandProcessor,
         [FromRoute] string name)
     {
-        var result = await mediator.Send(new GetRoleByNameQuery(name));
+        var result = await commandProcessor.Send(new GetRoleByNameQuery(name));
 
         if (result.Success)
         {

--- a/src/EChamado/Server/EChamado.Server/Endpoints/Roles/UpdateRoleEndpoint.cs
+++ b/src/EChamado/Server/EChamado.Server/Endpoints/Roles/UpdateRoleEndpoint.cs
@@ -1,8 +1,9 @@
-﻿using EChamado.Server.Application.UseCases.Roles.Commands;
+﻿using EChamado.Server.Application.Common.Messaging;
+using EChamado.Server.Application.UseCases.Roles.Commands;
 using EChamado.Server.Common.Api;
 using EChamado.Shared.Responses;
-using MediatR;
 using Microsoft.AspNetCore.Mvc;
+using Paramore.Brighter;
 
 namespace EChamado.Server.Endpoints.Roles;
 
@@ -17,7 +18,7 @@ public class UpdateRoleEndpoint : IEndpoint
         .Produces<BaseResult>();
 
     private static async Task<IResult> HandleAsync(
-        IMediator mediator,
+        IAmACommandProcessor commandProcessor,
         [FromRoute] Guid id,
         [FromBody] UpdateRoleCommand command)
     {
@@ -27,7 +28,7 @@ public class UpdateRoleEndpoint : IEndpoint
             return TypedResults.BadRequest("Id da rota e Id do corpo da requisição não são iguais");
         }
 
-        var result = await mediator.Send(command);
+        var result = await commandProcessor.Send(command);
 
         if (result.Success)
         {

--- a/src/EChamado/Server/EChamado.Server/Endpoints/StatusTypes/CreateStatusTypeEndpoint.cs
+++ b/src/EChamado/Server/EChamado.Server/Endpoints/StatusTypes/CreateStatusTypeEndpoint.cs
@@ -1,6 +1,7 @@
+using EChamado.Server.Application.Common.Messaging;
 using EChamado.Server.Application.UseCases.StatusTypes.Commands;
 using EChamado.Shared.Responses;
-using MediatR;
+using Paramore.Brighter;
 
 namespace EChamado.Server.Endpoints.StatusTypes;
 
@@ -12,7 +13,7 @@ public class CreateStatusTypeEndpoint : IEndpoint
             .Produces<BaseResult<Guid>>();
 
     private static async Task<IResult> HandleAsync(
-        IMediator mediator,
+        IAmACommandProcessor commandProcessor,
         CreateStatusTypeRequest request)
     {
         var command = new CreateStatusTypeCommand(
@@ -20,7 +21,7 @@ public class CreateStatusTypeEndpoint : IEndpoint
             request.Description
         );
 
-        var result = await mediator.Send(command);
+        var result = await commandProcessor.Send(command);
 
         if (result.Success)
             return TypedResults.Ok(result);

--- a/src/EChamado/Server/EChamado.Server/Endpoints/StatusTypes/DeleteStatusTypeEndpoint.cs
+++ b/src/EChamado/Server/EChamado.Server/Endpoints/StatusTypes/DeleteStatusTypeEndpoint.cs
@@ -1,6 +1,7 @@
+using EChamado.Server.Application.Common.Messaging;
 using EChamado.Server.Application.UseCases.StatusTypes.Commands;
 using EChamado.Shared.Responses;
-using MediatR;
+using Paramore.Brighter;
 
 namespace EChamado.Server.Endpoints.StatusTypes;
 
@@ -12,11 +13,11 @@ public class DeleteStatusTypeEndpoint : IEndpoint
             .Produces<BaseResult>();
 
     private static async Task<IResult> HandleAsync(
-        IMediator mediator,
+        IAmACommandProcessor commandProcessor,
         Guid id)
     {
         var command = new DeleteStatusTypeCommand(id);
-        var result = await mediator.Send(command);
+        var result = await commandProcessor.Send(command);
 
         if (result.Success)
             return TypedResults.Ok(result);

--- a/src/EChamado/Server/EChamado.Server/Endpoints/StatusTypes/GetStatusTypeByIdEndpoint.cs
+++ b/src/EChamado/Server/EChamado.Server/Endpoints/StatusTypes/GetStatusTypeByIdEndpoint.cs
@@ -1,7 +1,8 @@
+using EChamado.Server.Application.Common.Messaging;
 using EChamado.Server.Application.UseCases.StatusTypes.Queries;
 using EChamado.Server.Application.UseCases.StatusTypes.ViewModels;
 using EChamado.Shared.Responses;
-using MediatR;
+using Paramore.Brighter;
 
 namespace EChamado.Server.Endpoints.StatusTypes;
 
@@ -13,11 +14,11 @@ public class GetStatusTypeByIdEndpoint : IEndpoint
             .Produces<BaseResult<StatusTypeViewModel>>();
 
     private static async Task<IResult> HandleAsync(
-        IMediator mediator,
+        IAmACommandProcessor commandProcessor,
         Guid id)
     {
         var query = new GetStatusTypeByIdQuery(id);
-        var result = await mediator.Send(query);
+        var result = await commandProcessor.Send(query);
 
         if (result.Success)
             return TypedResults.Ok(result);

--- a/src/EChamado/Server/EChamado.Server/Endpoints/StatusTypes/SearchStatusTypesEndpoint.cs
+++ b/src/EChamado/Server/EChamado.Server/Endpoints/StatusTypes/SearchStatusTypesEndpoint.cs
@@ -1,8 +1,9 @@
+using EChamado.Server.Application.Common.Messaging;
 using EChamado.Server.Application.UseCases.StatusTypes.Queries;
 using EChamado.Server.Application.UseCases.StatusTypes.ViewModels;
 using EChamado.Shared.Responses;
-using MediatR;
 using Microsoft.AspNetCore.Mvc;
+using Paramore.Brighter;
 
 namespace EChamado.Server.Endpoints.StatusTypes;
 
@@ -14,7 +15,7 @@ public class SearchStatusTypesEndpoint : IEndpoint
             .Produces<BaseResultList<StatusTypeViewModel>>();
 
     private static async Task<IResult> HandleAsync(
-        IMediator mediator,
+        IAmACommandProcessor commandProcessor,
         [AsParameters] SearchStatusTypesParameters parameters)
     {
         var query = new SearchStatusTypesQuery
@@ -30,7 +31,7 @@ public class SearchStatusTypesEndpoint : IEndpoint
             PageSize = parameters.PageSize
         };
 
-        var result = await mediator.Send(query);
+        var result = await commandProcessor.Send(query);
 
         if (result.Success)
             return TypedResults.Ok(result);

--- a/src/EChamado/Server/EChamado.Server/Endpoints/StatusTypes/UpdateStatusTypeEndpoint.cs
+++ b/src/EChamado/Server/EChamado.Server/Endpoints/StatusTypes/UpdateStatusTypeEndpoint.cs
@@ -1,6 +1,7 @@
+using EChamado.Server.Application.Common.Messaging;
 using EChamado.Server.Application.UseCases.StatusTypes.Commands;
 using EChamado.Shared.Responses;
-using MediatR;
+using Paramore.Brighter;
 
 namespace EChamado.Server.Endpoints.StatusTypes;
 
@@ -12,7 +13,7 @@ public class UpdateStatusTypeEndpoint : IEndpoint
             .Produces<BaseResult>();
 
     private static async Task<IResult> HandleAsync(
-        IMediator mediator,
+        IAmACommandProcessor commandProcessor,
         Guid id,
         UpdateStatusTypeRequest request)
     {
@@ -22,7 +23,7 @@ public class UpdateStatusTypeEndpoint : IEndpoint
             request.Description
         );
 
-        var result = await mediator.Send(command);
+        var result = await commandProcessor.Send(command);
 
         if (result.Success)
             return TypedResults.Ok(result);

--- a/src/EChamado/Server/EChamado.Server/Endpoints/SubCategories/CreateSubCategoryEndpoint.cs
+++ b/src/EChamado/Server/EChamado.Server/Endpoints/SubCategories/CreateSubCategoryEndpoint.cs
@@ -1,6 +1,7 @@
+using EChamado.Server.Application.Common.Messaging;
 using EChamado.Server.Application.UseCases.Categories.Commands;
 using EChamado.Shared.Responses;
-using MediatR;
+using Paramore.Brighter;
 
 namespace EChamado.Server.Endpoints.SubCategories;
 
@@ -12,7 +13,7 @@ public class CreateSubCategoryEndpoint : IEndpoint
             .Produces<BaseResult<Guid>>();
 
     private static async Task<IResult> HandleAsync(
-        IMediator mediator,
+        IAmACommandProcessor commandProcessor,
         CreateSubCategoryRequest request)
     {
         var command = new CreateSubCategoryCommand(
@@ -21,7 +22,7 @@ public class CreateSubCategoryEndpoint : IEndpoint
             request.CategoryId
         );
 
-        var result = await mediator.Send(command);
+        var result = await commandProcessor.Send(command);
 
         if (result.Success)
             return TypedResults.Ok(result);

--- a/src/EChamado/Server/EChamado.Server/Endpoints/SubCategories/DeleteSubCategoryEndpoint.cs
+++ b/src/EChamado/Server/EChamado.Server/Endpoints/SubCategories/DeleteSubCategoryEndpoint.cs
@@ -1,6 +1,7 @@
+using EChamado.Server.Application.Common.Messaging;
 using EChamado.Server.Application.UseCases.Categories.Commands;
 using EChamado.Shared.Responses;
-using MediatR;
+using Paramore.Brighter;
 
 namespace EChamado.Server.Endpoints.SubCategories;
 
@@ -12,11 +13,11 @@ public class DeleteSubCategoryEndpoint : IEndpoint
             .Produces<BaseResult>();
 
     private static async Task<IResult> HandleAsync(
-        IMediator mediator,
+        IAmACommandProcessor commandProcessor,
         Guid id)
     {
         var command = new DeleteSubCategoryCommand(id);
-        var result = await mediator.Send(command);
+        var result = await commandProcessor.Send(command);
 
         if (result.Success)
             return TypedResults.Ok(result);

--- a/src/EChamado/Server/EChamado.Server/Endpoints/SubCategories/GetSubCategoryByIdEndpoint.cs
+++ b/src/EChamado/Server/EChamado.Server/Endpoints/SubCategories/GetSubCategoryByIdEndpoint.cs
@@ -1,7 +1,8 @@
+using EChamado.Server.Application.Common.Messaging;
 using EChamado.Server.Application.UseCases.Categories.ViewModels;
 using EChamado.Server.Application.UseCases.SubCategories.Queries;
 using EChamado.Shared.Responses;
-using MediatR;
+using Paramore.Brighter;
 
 namespace EChamado.Server.Endpoints.SubCategories;
 
@@ -13,11 +14,11 @@ public class GetSubCategoryByIdEndpoint : IEndpoint
             .Produces<BaseResult<SubCategoryViewModel>>();
 
     private static async Task<IResult> HandleAsync(
-        IMediator mediator,
+        IAmACommandProcessor commandProcessor,
         Guid id)
     {
         var query = new GetSubCategoryByIdQuery(id);
-        var result = await mediator.Send(query);
+        var result = await commandProcessor.Send(query);
 
         if (result.Success)
             return TypedResults.Ok(result);

--- a/src/EChamado/Server/EChamado.Server/Endpoints/SubCategories/SearchSubCategoriesEndpoint.cs
+++ b/src/EChamado/Server/EChamado.Server/Endpoints/SubCategories/SearchSubCategoriesEndpoint.cs
@@ -1,8 +1,9 @@
+using EChamado.Server.Application.Common.Messaging;
 using EChamado.Server.Application.UseCases.Categories.ViewModels;
 using EChamado.Server.Application.UseCases.SubCategories.Queries;
 using EChamado.Shared.Responses;
-using MediatR;
 using Microsoft.AspNetCore.Mvc;
+using Paramore.Brighter;
 
 namespace EChamado.Server.Endpoints.SubCategories;
 
@@ -14,7 +15,7 @@ public class SearchSubCategoriesEndpoint : IEndpoint
             .Produces<BaseResultList<SubCategoryViewModel>>();
 
     private static async Task<IResult> HandleAsync(
-        IMediator mediator,
+        IAmACommandProcessor commandProcessor,
         [AsParameters] SearchSubCategoriesParameters parameters)
     {
         var query = new SearchSubCategoriesQuery
@@ -31,7 +32,7 @@ public class SearchSubCategoriesEndpoint : IEndpoint
             PageSize = parameters.PageSize
         };
 
-        var result = await mediator.Send(query);
+        var result = await commandProcessor.Send(query);
 
         if (result.Success)
             return TypedResults.Ok(result);

--- a/src/EChamado/Server/EChamado.Server/Endpoints/SubCategories/UpdateSubCategoryEndpoint.cs
+++ b/src/EChamado/Server/EChamado.Server/Endpoints/SubCategories/UpdateSubCategoryEndpoint.cs
@@ -1,6 +1,7 @@
+using EChamado.Server.Application.Common.Messaging;
 using EChamado.Server.Application.UseCases.Categories.Commands;
 using EChamado.Shared.Responses;
-using MediatR;
+using Paramore.Brighter;
 
 namespace EChamado.Server.Endpoints.SubCategories;
 
@@ -12,7 +13,7 @@ public class UpdateSubCategoryEndpoint : IEndpoint
             .Produces<BaseResult>();
 
     private static async Task<IResult> HandleAsync(
-        IMediator mediator,
+        IAmACommandProcessor commandProcessor,
         Guid id,
         UpdateSubCategoryRequest request)
     {
@@ -23,7 +24,7 @@ public class UpdateSubCategoryEndpoint : IEndpoint
             request.CategoryId
         );
 
-        var result = await mediator.Send(command);
+        var result = await commandProcessor.Send(command);
 
         if (result.Success)
             return TypedResults.Ok(result);

--- a/src/EChamado/Server/EChamado.Server/Endpoints/Users/GetAllUsersEndpoint.cs
+++ b/src/EChamado/Server/EChamado.Server/Endpoints/Users/GetAllUsersEndpoint.cs
@@ -1,8 +1,9 @@
-﻿using EChamado.Server.Application.UseCases.Users.Queries;
+﻿using EChamado.Server.Application.Common.Messaging;
+using EChamado.Server.Application.UseCases.Users.Queries;
 using EChamado.Server.Application.UseCases.Users.ViewModels;
 using EChamado.Server.Common.Api;
 using EChamado.Shared.Responses;
-using MediatR;
+using Paramore.Brighter;
 
 namespace EChamado.Server.Endpoints.Users;
 
@@ -17,9 +18,9 @@ public class GetAllUsersEndpoint : IEndpoint
         .Produces<BaseResultList<ApplicationUserViewModel>>();
 
     private static async Task<IResult> HandleAsync(
-        IMediator mediator)
+        IAmACommandProcessor commandProcessor)
     {
-        var result = await mediator.Send(new GetAllUsersQuery());
+        var result = await commandProcessor.Send(new GetAllUsersQuery());
 
         if (result.Success)
         {

--- a/src/EChamado/Server/EChamado.Server/Endpoints/Users/GetByEmailUserEndpoint.cs
+++ b/src/EChamado/Server/EChamado.Server/Endpoints/Users/GetByEmailUserEndpoint.cs
@@ -1,9 +1,10 @@
-﻿using EChamado.Server.Application.UseCases.Users.Queries;
+﻿using EChamado.Server.Application.Common.Messaging;
+using EChamado.Server.Application.UseCases.Users.Queries;
 using EChamado.Server.Application.UseCases.Users.ViewModels;
 using EChamado.Server.Common.Api;
 using EChamado.Shared.Responses;
-using MediatR;
 using Microsoft.AspNetCore.Mvc;
+using Paramore.Brighter;
 
 namespace EChamado.Server.Endpoints.Users;
 
@@ -18,10 +19,10 @@ public class GetByEmailUserEndpoint : IEndpoint
         .Produces<BaseResult<ApplicationUserViewModel>>();
 
     private static async Task<IResult> HandleAsync(
-        IMediator mediator,
+        IAmACommandProcessor commandProcessor,
         [FromRoute] string email)
     {
-        var result = await mediator.Send(new GetByEmailUserQuery(email));
+        var result = await commandProcessor.Send(new GetByEmailUserQuery(email));
 
         if (result.Success)
         {

--- a/src/EChamado/Server/EChamado.Server/Endpoints/Users/GetByIdUserEndpoint.cs
+++ b/src/EChamado/Server/EChamado.Server/Endpoints/Users/GetByIdUserEndpoint.cs
@@ -1,9 +1,10 @@
-﻿using EChamado.Server.Application.UseCases.Users.Queries;
+﻿using EChamado.Server.Application.Common.Messaging;
+using EChamado.Server.Application.UseCases.Users.Queries;
 using EChamado.Server.Application.UseCases.Users.ViewModels;
 using EChamado.Server.Common.Api;
 using EChamado.Shared.Responses;
-using MediatR;
 using Microsoft.AspNetCore.Mvc;
+using Paramore.Brighter;
 
 namespace EChamado.Server.Endpoints.Users;
 
@@ -18,10 +19,10 @@ public class GetByIdUserEndpoint : IEndpoint
         .Produces<BaseResult<ApplicationUserViewModel>>();
 
     private static async Task<IResult> HandleAsync(
-        IMediator mediator,
+        IAmACommandProcessor commandProcessor,
         [FromRoute] Guid id)
     {
-        var result = await mediator.Send(new GetByIdUserQuery(id));
+        var result = await commandProcessor.Send(new GetByIdUserQuery(id));
 
         if (result.Success)
         {

--- a/src/EChamado/Server/EChamado.Server/Program.cs
+++ b/src/EChamado/Server/EChamado.Server/Program.cs
@@ -28,12 +28,6 @@ builder.Services.AddCors(options =>
 
 builder.Services.AddIdentityConfig(builder.Configuration);
 
-// Configuração MediatR
-builder.Services.AddMediatR(cfg =>
-{
-    cfg.RegisterServicesFromAssembly(typeof(EChamado.Server.Application.UseCases.Orders.Commands.CreateOrderCommand).Assembly);
-});
-
 // Health Checks
 builder.Services.AddHealthCheckConfiguration(builder.Configuration);
 


### PR DESCRIPTION
Migração completa do MediatR para Paramore.Brighter por questões de licença.

Alterações realizadas:
- Removido pacote MediatR (12.4.1)
- Adicionado Paramore.Brighter (10.1.2) e Paramore.Brighter.Extensions.DependencyInjection (10.1.2)

Infraestrutura:
- Criado BrighterRequest<TResult> como classe base para Commands/Queries com suporte a valores de retorno
- Criado CommandProcessorExtensions com métodos de extensão para API similar ao MediatR
- Migrado ValidationBehaviour para ValidationHandler<TRequest> com RequestValidationAttribute
- Migrado UnhandledExceptionBehaviour para UnhandledExceptionHandler<TRequest> com RequestLoggingAttribute

Conversões realizadas:
- 30 Commands: convertidos de record/IRequest para class/BrighterRequest
- 19 Queries: convertidos de record/IRequest para class/BrighterRequest
- 30 Command Handlers: convertidos de IRequestHandler para RequestHandlerAsync com atributos de pipeline
- 19 Query Handlers: convertidos de IRequestHandler para RequestHandlerAsync
- 21 Notifications: convertidas de INotification para IRequest
- 2 Notification Handlers: divididos em handlers individuais RequestHandlerAsync
- 49 Endpoints: atualizados de IMediator para IAmACommandProcessor

Configuração:
- Atualizado DependencyInjection.cs com configuração do Brighter usando AutoFromAssemblies
- Removido configuração duplicada do MediatR em Program.cs
- Registrados ValidationHandler e UnhandledExceptionHandler como transient

A migração mantém toda a funcionalidade existente e compatibilidade com CQRS, validação FluentValidation e pipeline de behaviors.