### PR TITLE
Add disabled status type notification handling

### DIFF
--- a/src/EChamado/Server/EChamado.Server.Application/UseCases/Categories/Notifications/Handlers/CategoryNotificationHandlers.cs
+++ b/src/EChamado/Server/EChamado.Server.Application/UseCases/Categories/Notifications/Handlers/CategoryNotificationHandlers.cs
@@ -1,0 +1,174 @@
+using EChamado.Server.Application.UseCases.Categories.Notifications;
+using EChamado.Server.Domain.Services.Interface;
+using Microsoft.Extensions.Logging;
+using Paramore.Brighter;
+
+namespace EChamado.Server.Application.UseCases.Categories.Notifications.Handlers;
+
+public class CreatedCategoryNotificationHandler(
+    IMessageBusClient messageBusClient,
+    ILogger<CreatedCategoryNotificationHandler> logger) :
+    RequestHandlerAsync<CreatedCategoryNotification>
+{
+    public override async Task<CreatedCategoryNotification> HandleAsync(
+        CreatedCategoryNotification notification,
+        CancellationToken cancellationToken = default)
+    {
+        if (notification == null)
+        {
+            logger.LogError("CreatedCategoryNotification is null");
+            return await base.HandleAsync(notification, cancellationToken);
+        }
+
+        await messageBusClient.Publish(
+            notification.ToString(),
+            "category.created",
+            "category-exchange",
+            "direct",
+            "create-category");
+
+        logger.LogInformation("CreatedCategoryNotification: {Notification}", notification);
+
+        return await base.HandleAsync(notification, cancellationToken);
+    }
+}
+
+public class UpdatedCategoryNotificationHandler(
+    IMessageBusClient messageBusClient,
+    ILogger<UpdatedCategoryNotificationHandler> logger) :
+    RequestHandlerAsync<UpdatedCategoryNotification>
+{
+    public override async Task<UpdatedCategoryNotification> HandleAsync(
+        UpdatedCategoryNotification notification,
+        CancellationToken cancellationToken = default)
+    {
+        if (notification == null)
+        {
+            logger.LogError("UpdatedCategoryNotification is null");
+            return await base.HandleAsync(notification, cancellationToken);
+        }
+
+        await messageBusClient.Publish(
+            notification.ToString(),
+            "category.updated",
+            "category-exchange",
+            "direct",
+            "update-category");
+
+        logger.LogInformation("UpdatedCategoryNotification: {Notification}", notification);
+
+        return await base.HandleAsync(notification, cancellationToken);
+    }
+}
+
+public class DeletedCategoryNotificationHandler(
+    IMessageBusClient messageBusClient,
+    ILogger<DeletedCategoryNotificationHandler> logger) :
+    RequestHandlerAsync<DeletedCategoryNotification>
+{
+    public override async Task<DeletedCategoryNotification> HandleAsync(
+        DeletedCategoryNotification notification,
+        CancellationToken cancellationToken = default)
+    {
+        if (notification == null)
+        {
+            logger.LogError("DeletedCategoryNotification is null");
+            return await base.HandleAsync(notification, cancellationToken);
+        }
+
+        await messageBusClient.Publish(
+            notification.ToString(),
+            "category.deleted",
+            "category-exchange",
+            "direct",
+            "delete-category");
+
+        logger.LogInformation("DeletedCategoryNotification: {Notification}", notification);
+
+        return await base.HandleAsync(notification, cancellationToken);
+    }
+}
+
+public class CreatedSubCategoryNotificationHandler(
+    IMessageBusClient messageBusClient,
+    ILogger<CreatedSubCategoryNotificationHandler> logger) :
+    RequestHandlerAsync<CreatedSubCategoryNotification>
+{
+    public override async Task<CreatedSubCategoryNotification> HandleAsync(
+        CreatedSubCategoryNotification notification,
+        CancellationToken cancellationToken = default)
+    {
+        if (notification == null)
+        {
+            logger.LogError("CreatedSubCategoryNotification is null");
+            return await base.HandleAsync(notification, cancellationToken);
+        }
+
+        await messageBusClient.Publish(
+            notification.ToString(),
+            "sub-category.created",
+            "sub-category-exchange",
+            "direct",
+            "create-sub-category");
+
+        logger.LogInformation("CreatedSubCategoryNotification: {Notification}", notification);
+
+        return await base.HandleAsync(notification, cancellationToken);
+    }
+}
+
+public class UpdatedSubCategoryNotificationHandler(
+    IMessageBusClient messageBusClient,
+    ILogger<UpdatedSubCategoryNotificationHandler> logger) :
+    RequestHandlerAsync<UpdatedSubCategoryNotification>
+{
+    public override async Task<UpdatedSubCategoryNotification> HandleAsync(
+        UpdatedSubCategoryNotification notification,
+        CancellationToken cancellationToken = default)
+    {
+        if (notification == null)
+        {
+            logger.LogError("UpdatedSubCategoryNotification is null");
+            return await base.HandleAsync(notification, cancellationToken);
+        }
+
+        await messageBusClient.Publish(
+            notification.ToString(),
+            "sub-category.updated",
+            "sub-category-exchange",
+            "direct",
+            "update-sub-category");
+
+        logger.LogInformation("UpdatedSubCategoryNotification: {Notification}", notification);
+
+        return await base.HandleAsync(notification, cancellationToken);
+    }
+}
+
+public class DeletedSubCategoryNotificationHandler(
+    IMessageBusClient messageBusClient,
+    ILogger<DeletedSubCategoryNotificationHandler> logger) :
+    RequestHandlerAsync<DeletedSubCategoryNotification>
+{
+    public override async Task<DeletedSubCategoryNotification> HandleAsync(
+        DeletedSubCategoryNotification notification,
+        CancellationToken cancellationToken = default)
+    {
+        if (notification == null)
+        {
+            logger.LogError("DeletedSubCategoryNotification is null");
+            return await base.HandleAsync(notification, cancellationToken);
+        }
+
+        await messageBusClient.Publish(
+            notification.ToString(),
+            "sub-category.deleted",
+            "sub-category-exchange",
+            "direct",
+            "delete-sub-category");
+
+        logger.LogInformation("DeletedSubCategoryNotification: {Notification}", notification);
+
+        return await base.HandleAsync(notification, cancellationToken);
+    }
+}

--- a/src/EChamado/Server/EChamado.Server.Application/UseCases/Comments/Notifications/Handlers/CommentNotificationHandlers.cs
+++ b/src/EChamado/Server/EChamado.Server.Application/UseCases/Comments/Notifications/Handlers/CommentNotificationHandlers.cs
@@ -1,0 +1,62 @@
+using EChamado.Server.Application.UseCases.Comments.Notifications;
+using EChamado.Server.Domain.Services.Interface;
+using Microsoft.Extensions.Logging;
+using Paramore.Brighter;
+
+namespace EChamado.Server.Application.UseCases.Comments.Notifications.Handlers;
+
+public class CreatedCommentNotificationHandler(
+    IMessageBusClient messageBusClient,
+    ILogger<CreatedCommentNotificationHandler> logger) :
+    RequestHandlerAsync<CreatedCommentNotification>
+{
+    public override async Task<CreatedCommentNotification> HandleAsync(
+        CreatedCommentNotification notification,
+        CancellationToken cancellationToken = default)
+    {
+        if (notification == null)
+        {
+            logger.LogError("CreatedCommentNotification is null");
+            return await base.HandleAsync(notification, cancellationToken);
+        }
+
+        await messageBusClient.Publish(
+            notification.ToString(),
+            "comment.created",
+            "comment-exchange",
+            "direct",
+            "create-comment");
+
+        logger.LogInformation("CreatedCommentNotification: {Notification}", notification);
+
+        return await base.HandleAsync(notification, cancellationToken);
+    }
+}
+
+public class DeletedCommentNotificationHandler(
+    IMessageBusClient messageBusClient,
+    ILogger<DeletedCommentNotificationHandler> logger) :
+    RequestHandlerAsync<DeletedCommentNotification>
+{
+    public override async Task<DeletedCommentNotification> HandleAsync(
+        DeletedCommentNotification notification,
+        CancellationToken cancellationToken = default)
+    {
+        if (notification == null)
+        {
+            logger.LogError("DeletedCommentNotification is null");
+            return await base.HandleAsync(notification, cancellationToken);
+        }
+
+        await messageBusClient.Publish(
+            notification.ToString(),
+            "comment.deleted",
+            "comment-exchange",
+            "direct",
+            "delete-comment");
+
+        logger.LogInformation("DeletedCommentNotification: {Notification}", notification);
+
+        return await base.HandleAsync(notification, cancellationToken);
+    }
+}

--- a/src/EChamado/Server/EChamado.Server.Application/UseCases/OrderTypes/Notifications/Handlers/OrderTypeNotificationHandlers.cs
+++ b/src/EChamado/Server/EChamado.Server.Application/UseCases/OrderTypes/Notifications/Handlers/OrderTypeNotificationHandlers.cs
@@ -1,0 +1,90 @@
+using EChamado.Server.Application.UseCases.OrderTypes.Notifications;
+using EChamado.Server.Domain.Services.Interface;
+using Microsoft.Extensions.Logging;
+using Paramore.Brighter;
+
+namespace EChamado.Server.Application.UseCases.OrderTypes.Notifications.Handlers;
+
+public class CreatedOrderTypeNotificationHandler(
+    IMessageBusClient messageBusClient,
+    ILogger<CreatedOrderTypeNotificationHandler> logger) :
+    RequestHandlerAsync<CreatedOrderTypeNotification>
+{
+    public override async Task<CreatedOrderTypeNotification> HandleAsync(
+        CreatedOrderTypeNotification notification,
+        CancellationToken cancellationToken = default)
+    {
+        if (notification == null)
+        {
+            logger.LogError("CreatedOrderTypeNotification is null");
+            return await base.HandleAsync(notification, cancellationToken);
+        }
+
+        await messageBusClient.Publish(
+            notification.ToString(),
+            "order-type.created",
+            "order-type-exchange",
+            "direct",
+            "create-order-type");
+
+        logger.LogInformation("CreatedOrderTypeNotification: {Notification}", notification);
+
+        return await base.HandleAsync(notification, cancellationToken);
+    }
+}
+
+public class UpdatedOrderTypeNotificationHandler(
+    IMessageBusClient messageBusClient,
+    ILogger<UpdatedOrderTypeNotificationHandler> logger) :
+    RequestHandlerAsync<UpdatedOrderTypeNotification>
+{
+    public override async Task<UpdatedOrderTypeNotification> HandleAsync(
+        UpdatedOrderTypeNotification notification,
+        CancellationToken cancellationToken = default)
+    {
+        if (notification == null)
+        {
+            logger.LogError("UpdatedOrderTypeNotification is null");
+            return await base.HandleAsync(notification, cancellationToken);
+        }
+
+        await messageBusClient.Publish(
+            notification.ToString(),
+            "order-type.updated",
+            "order-type-exchange",
+            "direct",
+            "update-order-type");
+
+        logger.LogInformation("UpdatedOrderTypeNotification: {Notification}", notification);
+
+        return await base.HandleAsync(notification, cancellationToken);
+    }
+}
+
+public class DeletedOrderTypeNotificationHandler(
+    IMessageBusClient messageBusClient,
+    ILogger<DeletedOrderTypeNotificationHandler> logger) :
+    RequestHandlerAsync<DeletedOrderTypeNotification>
+{
+    public override async Task<DeletedOrderTypeNotification> HandleAsync(
+        DeletedOrderTypeNotification notification,
+        CancellationToken cancellationToken = default)
+    {
+        if (notification == null)
+        {
+            logger.LogError("DeletedOrderTypeNotification is null");
+            return await base.HandleAsync(notification, cancellationToken);
+        }
+
+        await messageBusClient.Publish(
+            notification.ToString(),
+            "order-type.deleted",
+            "order-type-exchange",
+            "direct",
+            "delete-order-type");
+
+        logger.LogInformation("DeletedOrderTypeNotification: {Notification}", notification);
+
+        return await base.HandleAsync(notification, cancellationToken);
+    }
+}

--- a/src/EChamado/Server/EChamado.Server.Application/UseCases/StatusTypes/Notifications/DisabledStatusTypeNotification.cs
+++ b/src/EChamado/Server/EChamado.Server.Application/UseCases/StatusTypes/Notifications/DisabledStatusTypeNotification.cs
@@ -1,0 +1,29 @@
+using Paramore.Brighter;
+using System.Text.Json;
+
+namespace EChamado.Server.Application.UseCases.StatusTypes.Notifications;
+
+public class DisabledStatusTypeNotification : IRequest
+{
+    public Id Id { get; set; }
+    public Id CorrelationId { get; set; } = new Id(Guid.NewGuid().ToString());
+    public string Name { get; set; } = string.Empty;
+    public string Description { get; set; } = string.Empty;
+
+    public DisabledStatusTypeNotification()
+    {
+        Id = new Id(Guid.NewGuid().ToString());
+    }
+
+    public DisabledStatusTypeNotification(Guid id, string name, string description)
+    {
+        Id = new Id(id.ToString());
+        Name = name;
+        Description = description;
+    }
+
+    public override string? ToString()
+    {
+        return JsonSerializer.Serialize(this);
+    }
+}

--- a/src/EChamado/Server/EChamado.Server.Application/UseCases/StatusTypes/Notifications/Handlers/StatusTypeNotificationHandlers.cs
+++ b/src/EChamado/Server/EChamado.Server.Application/UseCases/StatusTypes/Notifications/Handlers/StatusTypeNotificationHandlers.cs
@@ -1,0 +1,118 @@
+using EChamado.Server.Application.UseCases.StatusTypes.Notifications;
+using EChamado.Server.Domain.Services.Interface;
+using Microsoft.Extensions.Logging;
+using Paramore.Brighter;
+
+namespace EChamado.Server.Application.UseCases.StatusTypes.Notifications.Handlers;
+
+public class CreatedStatusTypeNotificationHandler(
+    IMessageBusClient messageBusClient,
+    ILogger<CreatedStatusTypeNotificationHandler> logger) :
+    RequestHandlerAsync<CreatedStatusTypeNotification>
+{
+    public override async Task<CreatedStatusTypeNotification> HandleAsync(
+        CreatedStatusTypeNotification notification,
+        CancellationToken cancellationToken = default)
+    {
+        if (notification == null)
+        {
+            logger.LogError("CreatedStatusTypeNotification is null");
+            return await base.HandleAsync(notification, cancellationToken);
+        }
+
+        await messageBusClient.Publish(
+            notification.ToString(),
+            "status-type.created",
+            "status-type-exchange",
+            "direct",
+            "create-status-type");
+
+        logger.LogInformation("CreatedStatusTypeNotification: {Notification}", notification);
+
+        return await base.HandleAsync(notification, cancellationToken);
+    }
+}
+
+public class UpdatedStatusTypeNotificationHandler(
+    IMessageBusClient messageBusClient,
+    ILogger<UpdatedStatusTypeNotificationHandler> logger) :
+    RequestHandlerAsync<UpdatedStatusTypeNotification>
+{
+    public override async Task<UpdatedStatusTypeNotification> HandleAsync(
+        UpdatedStatusTypeNotification notification,
+        CancellationToken cancellationToken = default)
+    {
+        if (notification == null)
+        {
+            logger.LogError("UpdatedStatusTypeNotification is null");
+            return await base.HandleAsync(notification, cancellationToken);
+        }
+
+        await messageBusClient.Publish(
+            notification.ToString(),
+            "status-type.updated",
+            "status-type-exchange",
+            "direct",
+            "update-status-type");
+
+        logger.LogInformation("UpdatedStatusTypeNotification: {Notification}", notification);
+
+        return await base.HandleAsync(notification, cancellationToken);
+    }
+}
+
+public class DisabledStatusTypeNotificationHandler(
+    IMessageBusClient messageBusClient,
+    ILogger<DisabledStatusTypeNotificationHandler> logger) :
+    RequestHandlerAsync<DisabledStatusTypeNotification>
+{
+    public override async Task<DisabledStatusTypeNotification> HandleAsync(
+        DisabledStatusTypeNotification notification,
+        CancellationToken cancellationToken = default)
+    {
+        if (notification == null)
+        {
+            logger.LogError("DisabledStatusTypeNotification is null");
+            return await base.HandleAsync(notification, cancellationToken);
+        }
+
+        await messageBusClient.Publish(
+            notification.ToString(),
+            "status-type.disabled",
+            "status-type-exchange",
+            "direct",
+            "disable-status-type");
+
+        logger.LogInformation("DisabledStatusTypeNotification: {Notification}", notification);
+
+        return await base.HandleAsync(notification, cancellationToken);
+    }
+}
+
+public class DeletedStatusTypeNotificationHandler(
+    IMessageBusClient messageBusClient,
+    ILogger<DeletedStatusTypeNotificationHandler> logger) :
+    RequestHandlerAsync<DeletedStatusTypeNotification>
+{
+    public override async Task<DeletedStatusTypeNotification> HandleAsync(
+        DeletedStatusTypeNotification notification,
+        CancellationToken cancellationToken = default)
+    {
+        if (notification == null)
+        {
+            logger.LogError("DeletedStatusTypeNotification is null");
+            return await base.HandleAsync(notification, cancellationToken);
+        }
+
+        await messageBusClient.Publish(
+            notification.ToString(),
+            "status-type.deleted",
+            "status-type-exchange",
+            "direct",
+            "delete-status-type");
+
+        logger.LogInformation("DeletedStatusTypeNotification: {Notification}", notification);
+
+        return await base.HandleAsync(notification, cancellationToken);
+    }
+}


### PR DESCRIPTION
## Summary
- add a DisabledStatusTypeNotification to mirror the pattern used by departments
- publish disabled status type messages to the message bus with logging

## Testing
- `dotnet build src/EChamado/EChamado.sln -clp:DisableConsoleColor` *(fails: MSBuild terminal logger ArgumentOutOfRangeException in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6938ac7f54ec83309e58814629b01a04)